### PR TITLE
Add casting to string as first step of sanitizeString method

### DIFF
--- a/src/providers/api/modules/etlMods.py
+++ b/src/providers/api/modules/etlMods.py
@@ -29,6 +29,8 @@ def writeToFile(_data, _name):
 def sanitizeString(_data):
     if _data is None:
         return ''
+    else:
+        _data = str(_data)
 
     _data       = _data.strip()
     _data       = _data.replace('"', "'")


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->

**Description**
<!-- Add your description below. -->
This PR makes the `sanitizeString` method a bit more robust by giving it the ability to handle non-string input.

**Other information**
<!-- Add any other information below or delete the "Other Information" line entirely. -->
Because the ETL jobs occasionally process unknown data, the `sanitizeString` method was being called on non-string data on a regular basis (particularly when processing Flickr data).  It was then using string methods on that data, without first casting the data to a string.  Now, it casts data to a string, then sanitizes it.

**Checklist:**
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] I added tests for the changes I made (if applicable).
- [X] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
