### PR TITLE
extract row-writing function from Flickr.py

### DIFF
--- a/src/providers/api/Flickr.py
+++ b/src/providers/api/Flickr.py
@@ -9,9 +9,15 @@ Notes:                  https://www.flickr.com/help/terms/api
                         Rate limit: 3600 queries per hour.
 """
 
-from modules.etlMods import *
+import argparse
 import calendar
+import logging
+import os
+import time
+from datetime import datetime, timedelta
 from dateutil import rrule
+
+import modules.etlMods as em
 
 logging.getLogger(__name__)
 Ts_RANGE    = int(5) #process job using 5 minute intervals
@@ -20,17 +26,15 @@ FILE        = 'flickr_{}.tsv'.format(int(time.time()))
 SIZE        = 500
 API_KEY     = os.environ['FLICKR_API_KEY']
 FLICKR      = 'flickr'
+ENDPOINT    = 'https://api.flickr.com/services/rest/?method=flickr.photos.search'
 
+logging.basicConfig(
+    format='%(asctime)s: [%(levelname)s - Flickr API] =======> %(message)s',
+    level=logging.INFO)
 
-URL      = None
-#QUERY    = 'https://api.flickr.com/services/rest/?method=flickr.photos.search&api_key={0}&min_upload_date={1}&max_upload_date={2}&license=1&media=photos&content_type=1&extras=description,license,date_upload,date_taken,owner_name,tags,o_dims,url_t,url_s,url_m,url_l&per_page={3}&format=json&nojsoncallback=1'.format(API, MIN_DATE, MAX_DATE, SIZE)
-
-logging.basicConfig(format='%(asctime)s: [%(levelname)s - Flickr API] =======> %(message)s', level=logging.INFO)
-#logging.info('processing date range: {} - {}'.format(MIN_DATE, MAX_DATE))
-
-def getLicense(_index):
-    version     = 2.0
-    ccLicense   = {
+def get_license(_index):
+    version = 2.0
+    cc_license = {
         1:  'by-nc-sa',
         2:  'by-nc',
         3:  'by-nc-nd',
@@ -42,7 +46,7 @@ def getLicense(_index):
     }
 
     if _index == 'all':
-        return ccLicense.keys()
+        return cc_license.keys()
     else:
         _index  = int(_index)
 
@@ -52,12 +56,12 @@ def getLicense(_index):
         return None, None
 
 
-    license = ccLicense[_index]
+    license_ = cc_license[_index]
 
     if _index in [9, 10]:
         version = 1.0
 
-    return license, version
+    return license_, version
 
 
 def get_image_url(_data):
@@ -76,12 +80,12 @@ def get_image_url(_data):
 def create_meta_data_dict(_data):
     meta_data = {}
     if 'dateupload' in _data:
-        meta_data['pub_date'] = sanitizeString(_data.get('dateupload'))
+        meta_data['pub_date'] = em.sanitizeString(_data.get('dateupload'))
 
     if 'datetaken' in _data:
-        meta_data['date_taken'] = sanitizeString(_data.get('datetaken'))
+        meta_data['date_taken'] = em.sanitizeString(_data.get('datetaken'))
 
-    description = sanitizeString(_data.get('description', {}).get('_content'))
+    description = em.sanitizeString(_data.get('description', {}).get('_content'))
     if description:
         meta_data['description'] = description
 
@@ -98,108 +102,125 @@ def create_tags_list(_data):
         return None
 
 
-def extractData(_data):
+def extract_data(_data):
     title = _data.get('title')
     creator = _data.get('ownername')
-    imageURL, height, width = get_image_url(_data)
+    image_url, height, width = get_image_url(_data)
     thumbnail = _data.get('url_s')
-    license, version = getLicense(_data.get('license', -1))
-    metaData = create_meta_data_dict(_data)
-    tagData = create_tags_list(_data)
+    license_, version = get_license(_data.get('license', -1))
+    meta_data = create_meta_data_dict(_data)
+    tags = create_tags_list(_data)
 
     if 'owner' in _data:
-        creatorURL = 'www.flickr.com/photos/{}'.format(_data['owner']).strip()
+        creator_url = 'www.flickr.com/photos/{}'.format(_data['owner']).strip()
     else:
-        creatorURL = None
+        creator_url = None
 
-    foreignID = _data.get('id')
+    foreign_id = _data.get('id')
 
-    if foreignID and creatorURL:
-        foreignURL = '{}/{}'.format(creatorURL, foreignID)
+    if foreign_id and creator_url:
+        foreign_url = '{}/{}'.format(creator_url, foreign_id)
     else:
-        foreignURL = None
+        foreign_url = None
 
 
-    return create_tsv_list_row(
-        foreign_identifier=imageURL if not foreignID else foreignID,
-        foreign_landing_url=foreignURL,
-        image_url=imageURL,
+    return em.create_tsv_list_row(
+        foreign_identifier=image_url if not foreign_id else foreign_id,
+        foreign_landing_url=foreign_url,
+        image_url=image_url,
         thumbnail=thumbnail,
         width=width,
         height=height,
-        license=license,
+        license_=license_,
         license_version=version,
         creator=creator,
-        creator_url=creatorURL,
+        creator_url=creator_url,
         title=title,
-        meta_data=metaData,
-        tags=tagData,
+        meta_data=meta_data,
+        tags=tags,
         watermarked='f',
         provider=FLICKR,
         source=FLICKR
     )
 
 
-def getMetaData(_startTs, _endTs, _license, _switchDate=False):
-    procTime    = time.time()
+def construct_api_query_string(
+        start_ts,
+        end_ts,
+        license_,
+        cur_page,
+        switch_date=False):
+    date_type = 'taken' if switch_date else 'upload'
+    api_query_string = (
+        '{0}&api_key={1}&min_{7}_date={2}&max_{7}_date={3}&license={5}'
+        '&media=photos&content_type=1&extras=description,license,date_upload,'
+        'date_taken,owner_name,tags,o_dims,url_t,url_s,url_m,url_l'
+        '&per_page={4}&format=json&nojsoncallback=1&page={6}'
+    ).format(
+        ENDPOINT, API_KEY, start_ts, end_ts, SIZE, license_, cur_page, date_type)
+
+    return api_query_string
+
+
+def process_images(start_ts, end_ts, license_, switch_date=False):
+    proc_time    = time.time()
     pages       = 1
-    curPage     = 1
-    numImages   = 0
-    endpoint    = 'https://api.flickr.com/services/rest/?method=flickr.photos.search'
+    cur_page     = 1
+    num_images   = 0
 
 
-    while curPage <= pages:
+    while cur_page <= pages:
         #loop through each page of data
-        logging.info('Processing page: {}'.format(curPage))
+        logging.info('Processing page: {}'.format(cur_page))
 
-        queryStr    = '{0}&api_key={1}&min_upload_date={2}&max_upload_date={3}&license={5}&media=photos&content_type=1&extras=description,license,date_upload,date_taken,owner_name,tags,o_dims,url_t,url_s,url_m,url_l&per_page={4}&format=json&nojsoncallback=1&page={6}'.format(endpoint, API_KEY, _startTs, _endTs, SIZE, _license, curPage)
+        api_query_string = construct_api_query_string(
+            start_ts,
+            end_ts,
+            license_,
+            cur_page,
+            switch_date
+        )
 
-        if _switchDate:
-            queryStr = queryStr.replace('upload_date', 'taken_date')
+        img_data = em.requestContent(api_query_string)
+        if img_data and img_data.get('stat') == 'ok':
+            result  = img_data.get('photos', {})
+            pages   = result.get('pages')   #number of pages
+            cur_page = result.get('page')    #current page
+            photos  = result.get('photo')   #image meta data for the current page
 
-        imgData     = requestContent(queryStr)
-        if imgData:
-            status = imgData['stat']
-            if status == 'ok':
-                result  = imgData['photos']
-                total   = result['total']   #total results
-                pages   = result['pages']   #number of pages
-                curPage = result['page']    #current page
-                photos  = result['photo']   #image meta data for the current page
+            if photos:
+                # TODO update to >= python3.8, use walrus assignment
+                extracted = [r for r in (extract_data(p) for p in photos) if r]
+                num_images += len(extracted)
+                em.writeToFile(extracted, FILE)
 
-                if photos:
-                    extracted = list(map(lambda photo: extractData(photo), photos))
-                    extracted = list(filter(None, extracted))
-                    numImages += len(extracted)
-                    writeToFile(extracted, FILE)
-
-        curPage += 1
-        delayProcessing(procTime, DELAY) #throttle requests
-        procTime = time.time()
+        cur_page += 1
+        em.delayProcessing(proc_time, DELAY) #throttle requests
+        proc_time = time.time()
 
     logging.info('Total pages processed: {}'.format(pages))
 
-    return numImages
+    return num_images
 
 
-def execJob(_license, _startDate, _duration=1, _mode=None):
-    totalImages = 0
-    srtTime     = datetime.strptime(_startDate, '%Y-%m-%d %H:%M')
-    endTime     = datetime.strptime(_startDate, '%Y-%m-%d %H:%M') + timedelta(hours=_duration)
+def exec_job(license_, start_date, _duration=1, _mode=None):
+    total_images = 0
+    start_time = datetime.strptime(start_date, '%Y-%m-%d %H:%M')
+    end_time = datetime.strptime(start_date, '%Y-%m-%d %H:%M') + timedelta(hours=_duration)
 
-    for dt in rrule.rrule(rrule.MINUTELY, dtstart=srtTime, until=endTime):
-        elapsed = int((dt - srtTime).seconds/60)
+    for dt in rrule.rrule(rrule.MINUTELY, dtstart=start_time, until=end_time):
+        elapsed = int((dt - start_time).seconds/60)
 
         if elapsed % Ts_RANGE == 0:
             curTime = dt
             nxtTime = curTime + timedelta(minutes=Ts_RANGE)
-            logging.info('Processing dates: {} to {}, license: {}'.format(curTime, nxtTime, getLicense(_license)[0]))
+            logging.info('Processing dates: {} to {}, license: {}'.format(curTime, nxtTime, get_license(license_)[0]))
 
             #get the meta data within the time interval
-            totalImages += getMetaData(curTime, nxtTime, _license) #check upload_date
-            totalImages += getMetaData(curTime, nxtTime, _license, True) #check taken_date
+            total_images += process_images(curTime, nxtTime, license_) #check upload_date
+            total_images += process_images(curTime, nxtTime, license_, True) #check taken_date
 
-    logging.info('Total {} images: {}'.format(getLicense(_license)[0], totalImages))
+    logging.info('Total {} images: {}'.format(get_license(license_)[0], total_images))
 
 
 def main():
@@ -236,7 +257,8 @@ def main():
 
     #run the job and identify images for each CC license
     if param:
-        list(map(lambda license: execJob(license, param, duration), list(getLicense('all'))))
+        for license_ in get_license('all'):
+            exec_job(license_, param, duration)
 
     logging.info('Terminated!')
 

--- a/src/providers/api/modules/etlMods.py
+++ b/src/providers/api/modules/etlMods.py
@@ -12,6 +12,60 @@ from urllib.parse import urlparse
 
 PATH    = os.environ['OUTPUT_DIR']
 
+def _prepare_output_string(unknown_input):
+    if not unknown_input:
+        return '\\N'
+    elif type(unknown_input) in [dict, list]:
+        return json.dumps(unknown_input)
+    else:
+        return sanitizeString(unknown_input)
+
+
+def create_tsv_list_row(
+        foreign_identifier = None,
+        foreign_landing_url = None,
+        image_url = None,
+        thumbnail = None,
+        width = None,
+        height = None,
+        filesize = None,
+        license = None,
+        license_version = None,
+        creator = None,
+        creator_url = None,
+        title = None,
+        meta_data = None,
+        tags = None,
+        watermarked = 'f',
+        provider = None,
+        source = None):
+
+    raw_output_list = [
+        foreign_identifier,
+        foreign_landing_url,
+        image_url,
+        thumbnail,
+        width,
+        height,
+        filesize,
+        license,
+        license_version,
+        creator,
+        creator_url,
+        title,
+        meta_data,
+        tags,
+        watermarked,
+        provider,
+        source
+    ]
+
+    if foreign_landing_url and image_url and license:
+        return [_prepare_output_string(item) for item in raw_output_list]
+    else:
+        return None
+
+
 def writeToFile(_data, _name, output_dir=PATH):
     outputFile = '{}{}'.format(output_dir, _name)
 

--- a/src/providers/api/modules/etlMods.py
+++ b/src/providers/api/modules/etlMods.py
@@ -29,7 +29,7 @@ def create_tsv_list_row(
         width = None,
         height = None,
         filesize = None,
-        license = None,
+        license_ = None,
         license_version = None,
         creator = None,
         creator_url = None,
@@ -48,7 +48,7 @@ def create_tsv_list_row(
         width,
         height,
         filesize,
-        license,
+        license_,
         license_version,
         creator,
         creator_url,
@@ -60,7 +60,7 @@ def create_tsv_list_row(
         source
     ]
 
-    if foreign_landing_url and image_url and license:
+    if foreign_landing_url and image_url and license_:
         return [_prepare_output_string(item) for item in raw_output_list]
     else:
         return None

--- a/src/providers/api/modules/test_etlMods.py
+++ b/src/providers/api/modules/test_etlMods.py
@@ -1,0 +1,162 @@
+import etlMods
+import json
+
+def test_create_tsv_list_row_returns_none_if_missing_foreign_landing_url():
+    expect_row = None
+    actual_row = etlMods.create_tsv_list_row(
+        foreign_identifier='a',
+        image_url = 'a',
+        license = 'abc'
+    )
+    assert expect_row == actual_row
+
+def test_create_tsv_list_row_returns_none_if_missing_license():
+    expect_row = None
+    actual_row = etlMods.create_tsv_list_row(
+        foreign_identifier='a',
+        image_url = 'a',
+        foreign_landing_url = 'www.testurl.com'
+    )
+    assert expect_row == actual_row
+
+def test_create_tsv_list_row_returns_none_if_missing_image_url():
+    expect_row = None
+    actual_row = etlMods.create_tsv_list_row(
+        foreign_identifier='a',
+        foreign_landing_url = 'www.testurl.com',
+        license = 'abc'
+    )
+    assert expect_row == actual_row
+
+def test_create_tsv_list_row_casts_to_strings():
+    meta_data = {'key1': 'value1', 'key2': 'value2'}
+    tags = [
+        {'name': 'valuea', 'provider': 'valueb'},
+        {'name': 'aname', 'provider': 'aprovider'}
+    ]
+    height = 234
+    width = 102314
+
+    actual_row = etlMods.create_tsv_list_row(
+        foreign_landing_url = 'www.testurl.comk',
+        image_url = 'a',
+        license = 'abc',
+        width = width,
+        height = height,
+        meta_data = meta_data,
+        tags = tags
+    )
+    assert all([type(element) == str for element in actual_row])
+
+
+def test_create_tsv_list_row_handles_empty_dict_and_tags():
+    meta_data = {}
+    tags = []
+
+    actual_row = etlMods.create_tsv_list_row(
+        foreign_landing_url = 'www.testurl.comk',
+        image_url = 'a',
+        license = 'abc',
+        meta_data = meta_data,
+        tags = tags
+    )
+    actual_meta_data, actual_tags = actual_row[12], actual_row[13]
+    expect_meta_data, expect_tags = '\\N', '\\N'
+    assert expect_meta_data == actual_meta_data
+    assert expect_tags == actual_tags
+
+
+def test_create_tsv_list_row_turns_empty_into_nullchar():
+    req_args_dict = {
+        'foreign_landing_url': 'landing_page.com',
+        'image_url': 'imageurl.com',
+        'license': 'testlicense',
+    }
+    args_dict = {
+        'foreign_identifier': None,
+        'thumbnail': None,
+        'width': None,
+        'height': None,
+        'filesize': None,
+        'license_version': None,
+        'creator': None,
+        'creator_url': None,
+        'title': None,
+        'meta_data': None,
+        'tags': None,
+        'watermarked': 'f',
+        'provider': None,
+        'source': None
+    }
+    args_dict.update(req_args_dict)
+
+    actual_row = etlMods.create_tsv_list_row(
+        **args_dict
+    )
+    expect_row = [
+        '\\N',
+        'landing_page.com',
+        'imageurl.com',
+        '\\N',
+        '\\N',
+        '\\N',
+        '\\N',
+        'testlicense',
+        '\\N',
+        '\\N',
+        '\\N',
+        '\\N',
+        '\\N',
+        '\\N',
+        'f',
+        '\\N',
+        '\\N'
+    ]
+
+
+def test_create_tsv_list_row_properly_places_entries():
+    req_args_dict = {
+        'foreign_landing_url': 'landing_page.com',
+        'image_url': 'imageurl.com',
+        'license': 'testlicense',
+    }
+    args_dict = {
+        'foreign_identifier': 'foreign_id',
+        'thumbnail': 'thumbnail.com',
+        'width': 200,
+        'height': 500,
+        'license_version': '1.0',
+        'creator': 'tyler',
+        'creator_url': 'creatorurl.com',
+        'title': 'agreatpicture',
+        'meta_data': {'description': 'cat picture'},
+        'tags': [{'name': 'tag1', 'provider': 'testing'}],
+        'watermarked': 'f',
+        'provider': 'testing',
+        'source': 'testing'
+    }
+    args_dict.update(req_args_dict)
+
+    actual_row = etlMods.create_tsv_list_row(
+        **args_dict
+    )
+    expect_row = [
+        'foreign_id',
+        'landing_page.com',
+        'imageurl.com',
+        'thumbnail.com',
+        '200',
+        '500',
+        '\\N',
+        'testlicense',
+        '1.0',
+        'tyler',
+        'creatorurl.com',
+        'agreatpicture',
+        '{"description": "cat picture"}',
+        '[{"name": "tag1", "provider": "testing"}]',
+        'f',
+        'testing',
+        'testing'
+    ]
+    assert expect_row == actual_row

--- a/src/providers/api/modules/test_etlMods.py
+++ b/src/providers/api/modules/test_etlMods.py
@@ -6,7 +6,7 @@ def test_create_tsv_list_row_returns_none_if_missing_foreign_landing_url():
     actual_row = etlMods.create_tsv_list_row(
         foreign_identifier='a',
         image_url = 'a',
-        license = 'abc'
+        license_ = 'abc'
     )
     assert expect_row == actual_row
 
@@ -24,7 +24,7 @@ def test_create_tsv_list_row_returns_none_if_missing_image_url():
     actual_row = etlMods.create_tsv_list_row(
         foreign_identifier='a',
         foreign_landing_url = 'www.testurl.com',
-        license = 'abc'
+        license_ = 'abc'
     )
     assert expect_row == actual_row
 
@@ -40,7 +40,7 @@ def test_create_tsv_list_row_casts_to_strings():
     actual_row = etlMods.create_tsv_list_row(
         foreign_landing_url = 'www.testurl.comk',
         image_url = 'a',
-        license = 'abc',
+        license_ = 'abc',
         width = width,
         height = height,
         meta_data = meta_data,
@@ -56,7 +56,7 @@ def test_create_tsv_list_row_handles_empty_dict_and_tags():
     actual_row = etlMods.create_tsv_list_row(
         foreign_landing_url = 'www.testurl.comk',
         image_url = 'a',
-        license = 'abc',
+        license_ = 'abc',
         meta_data = meta_data,
         tags = tags
     )
@@ -70,7 +70,7 @@ def test_create_tsv_list_row_turns_empty_into_nullchar():
     req_args_dict = {
         'foreign_landing_url': 'landing_page.com',
         'image_url': 'imageurl.com',
-        'license': 'testlicense',
+        'license_': 'testlicense',
     }
     args_dict = {
         'foreign_identifier': None,
@@ -118,7 +118,7 @@ def test_create_tsv_list_row_properly_places_entries():
     req_args_dict = {
         'foreign_landing_url': 'landing_page.com',
         'image_url': 'imageurl.com',
-        'license': 'testlicense',
+        'license_': 'testlicense',
     }
     args_dict = {
         'foreign_identifier': 'foreign_id',

--- a/src/providers/api/test_Flickr.py
+++ b/src/providers/api/test_Flickr.py
@@ -69,8 +69,8 @@ def test_process_images(monkeypatch):
         }
     tmp_directory = '/tmp/'
     output_filename = 'flickr_test.tsv'
-    monkeypatch.setattr(Flickr.em, "requestContent", mockresult)
-    monkeypatch.setattr(Flickr.em.writeToFile, '__defaults__', (tmp_directory,))
+    monkeypatch.setattr(Flickr.etl_mods, "requestContent", mockresult)
+    monkeypatch.setattr(Flickr.etl_mods.writeToFile, '__defaults__', (tmp_directory,))
     monkeypatch.setattr(Flickr, "FILE", output_filename)
     output_fullpath = os.path.join(tmp_directory, output_filename)
     try:
@@ -152,8 +152,8 @@ def test_process_images_handles_missing_required_info(monkeypatch):
         }
     tmp_directory = '/tmp/'
     output_filename = 'flickr_test.tsv'
-    monkeypatch.setattr(Flickr.em, "requestContent", mockresult)
-    monkeypatch.setattr(Flickr.em.writeToFile, '__defaults__', (tmp_directory,))
+    monkeypatch.setattr(Flickr.etl_mods, "requestContent", mockresult)
+    monkeypatch.setattr(Flickr.etl_mods.writeToFile, '__defaults__', (tmp_directory,))
     monkeypatch.setattr(Flickr, "FILE", output_filename)
     output_fullpath = os.path.join(tmp_directory, output_filename)
     try:
@@ -174,7 +174,7 @@ def test_process_images_handles_empty_json(monkeypatch):
     nxt_time = datetime.strptime('2019-12-02', '%Y-%m-%d')
     def mockresult(a_url):
         return {}
-    monkeypatch.setattr(Flickr.em, "requestContent", mockresult)
+    monkeypatch.setattr(Flickr.etl_mods, "requestContent", mockresult)
     expected_records = 0
     actual_records = Flickr.process_images(cur_time, nxt_time, 'potato')
     assert expected_records == actual_records

--- a/src/providers/api/test_Flickr.py
+++ b/src/providers/api/test_Flickr.py
@@ -84,3 +84,240 @@ def test_getMetaData(monkeypatch):
     with open(output_fullpath) as f:
         actual_filestring = f.read()
     assert expected_filestring == actual_filestring
+
+
+def test_extractData_returns_Nonetype_if_no_image():
+    data = {
+        "id": "456",
+        "owner": "456@N04",
+        "title": "233 Ordesa sept 2019",
+        "license": "3",
+        "description": {
+            "_content": "OLYMPUS DIGITAL CAMERA"
+        },
+        "dateupload": "1571326372",
+        "datetaken": "2019-09-07 16:26:44",
+        "ownername": "RADIOfotoGRAFIANDO",
+        "tags": "amarilla",
+        "url_t": "https://live.staticflickr.com/456_t.jpg",
+        "height_t": 75,
+        "width_t": 100,
+    }
+    actual_row = Flickr.extractData(data)
+    expect_row = None
+    assert expect_row == actual_row
+
+
+def test_get_image_url_returns_Nonetype_tuple_if_no_image():
+    data = {
+        "id": "456",
+        "owner": "456@N04",
+        "title": "233 Ordesa sept 2019",
+        "license": "3",
+        "description": {
+            "_content": "OLYMPUS DIGITAL CAMERA"
+        },
+        "dateupload": "1571326372",
+        "datetaken": "2019-09-07 16:26:44",
+        "ownername": "RADIOfotoGRAFIANDO",
+        "tags": "amarilla",
+        "url_t": "https://live.staticflickr.com/456_t.jpg",
+        "height_t": 75,
+        "width_t": 100,
+    }
+    actual_tuple = Flickr.get_image_url(data)
+    expect_tuple = (None, None, None)
+    assert expect_tuple == actual_tuple
+
+
+def test_get_image_url_returns_large_tuple_when_avail():
+    data = {
+        "id": "456",
+        "owner": "456@N04",
+        "title": "233 Ordesa sept 2019",
+        "license": "3",
+        "description": {
+            "_content": "OLYMPUS DIGITAL CAMERA"
+        },
+        "dateupload": "1571326372",
+        "datetaken": "2019-09-07 16:26:44",
+        "ownername": "RADIOfotoGRAFIANDO",
+        "tags": "amarilla",
+        "url_t": "https://live.staticflickr.com/456_t.jpg",
+        "height_t": 75,
+        "width_t": 100,
+        "url_s": "https://live.staticflickr.com/456_m.jpg",
+        "height_s": 180,
+        "width_s": 240,
+        "url_m": "https://live.staticflickr.com/456.jpg",
+        "height_m": 375,
+        "width_m": 500,
+        "url_l": "https://live.staticflickr.com/456_b.jpg",
+        "height_l": 768,
+        "width_l": 1024
+    }
+    actual_tuple = Flickr.get_image_url(data)
+    expect_tuple = ('https://live.staticflickr.com/456_b.jpg', 768, 1024)
+    assert expect_tuple == actual_tuple
+
+
+def test_get_image_url_returns_medium_tuple_when_large_not_avail():
+    data = {
+        "id": "456",
+        "owner": "456@N04",
+        "title": "233 Ordesa sept 2019",
+        "license": "3",
+        "description": {
+            "_content": "OLYMPUS DIGITAL CAMERA"
+        },
+        "dateupload": "1571326372",
+        "datetaken": "2019-09-07 16:26:44",
+        "ownername": "RADIOfotoGRAFIANDO",
+        "tags": "amarilla",
+        "url_t": "https://live.staticflickr.com/456_t.jpg",
+        "height_t": 75,
+        "width_t": 100,
+        "url_s": "https://live.staticflickr.com/456_m.jpg",
+        "height_s": 180,
+        "width_s": 240,
+        "url_m": "https://live.staticflickr.com/456.jpg",
+        "height_m": 375,
+        "width_m": 500,
+    }
+    actual_tuple = Flickr.get_image_url(data)
+    expect_tuple = ('https://live.staticflickr.com/456.jpg', 375, 500)
+    assert expect_tuple == actual_tuple
+
+
+def test_get_image_url_falls_to_small_tuple():
+    data = {
+        "id": "456",
+        "owner": "456@N04",
+        "title": "233 Ordesa sept 2019",
+        "license": "3",
+        "description": {
+            "_content": "OLYMPUS DIGITAL CAMERA"
+        },
+        "dateupload": "1571326372",
+        "datetaken": "2019-09-07 16:26:44",
+        "ownername": "RADIOfotoGRAFIANDO",
+        "tags": "amarilla",
+        "url_t": "https://live.staticflickr.com/456_t.jpg",
+        "height_t": 75,
+        "width_t": 100,
+        "url_s": "https://live.staticflickr.com/456_m.jpg",
+        "height_s": 180,
+        "width_s": 240,
+    }
+    actual_tuple = Flickr.get_image_url(data)
+    expect_tuple = ('https://live.staticflickr.com/456_m.jpg', 180, 240)
+    assert expect_tuple == actual_tuple
+
+
+def test_extractData_returns_Nonetype_when_no_license():
+    data = {
+        "id": "456",
+        "owner": "456@N04",
+        "title": "233 Ordesa sept 2019",
+        "description": {
+            "_content": "OLYMPUS DIGITAL CAMERA"
+        },
+        "dateupload": "1571326372",
+        "datetaken": "2019-09-07 16:26:44",
+        "ownername": "RADIOfotoGRAFIANDO",
+        "tags": "amarilla",
+        "url_t": "https://live.staticflickr.com/456_t.jpg",
+        "height_t": 75,
+        "width_t": 100,
+        "url_l": "https://live.staticflickr.com/456_b.jpg",
+        "height_l": 768,
+        "width_l": 1024
+    }
+    actual_row = Flickr.extractData(data)
+    expect_row = None
+    assert expect_row == actual_row
+
+
+def test_create_meta_data_fills_meta_data_dict():
+    data = {
+        "title": "233 Ordesa sept 2019",
+        "description": {
+            "_content": "OLYMPUS DIGITAL CAMERA"
+        },
+        "dateupload": "1571326372",
+        "datetaken": "2019-09-07 16:26:44",
+        "ownername": "RADIOfotoGRAFIANDO",
+        "tags": "amarilla",
+    }
+    actual_dict = Flickr.create_meta_data_dict(data)
+    expect_dict = {
+        'pub_date': '1571326372',
+        'date_taken': '2019-09-07 16:26:44',
+        'description': 'OLYMPUS DIGITAL CAMERA'
+    }
+    assert expect_dict == actual_dict
+
+
+def test_create_meta_data_fills_partial_meta_data_dict():
+    data = {
+        "title": "233 Ordesa sept 2019",
+        "dateupload": "1571326372",
+        "datetaken": "2019-09-07 16:26:44",
+        "ownername": "RADIOfotoGRAFIANDO",
+        "tags": "amarilla",
+    }
+    actual_dict = Flickr.create_meta_data_dict(data)
+    expect_dict = {
+        'pub_date': '1571326372',
+        'date_taken': '2019-09-07 16:26:44'
+    }
+    assert expect_dict == actual_dict
+
+
+def test_create_meta_data_makes_empty_meta_data_dict():
+    data = {
+        "ownername": "RADIOfotoGRAFIANDO",
+        "tags": "amarilla",
+    }
+    actual_dict = Flickr.create_meta_data_dict(data)
+    expect_dict = {}
+    assert expect_dict == actual_dict
+
+
+def test_create_tags_list_makes_tags_list():
+    data = {
+        "id": "456",
+        "tags": "tag1 tag2   tag3  tag3 ",
+        "width_l": 1024
+    }
+    actual_tags_list = Flickr.create_tags_list(data)
+    expect_tags_list = [
+        {
+            'name': 'tag1',
+            'provider': 'flickr'
+        },
+        {
+            'name': 'tag2',
+            'provider': 'flickr'
+        },
+        {
+            'name': 'tag3',
+            'provider': 'flickr'
+        }
+    ]
+    assert len(actual_tags_list) == len(expect_tags_list)
+    assert all(
+        [element in actual_tags_list for element in expect_tags_list]
+    )
+
+
+def test_create_tags_list_returns_falsy_no_tag_key():
+    data = {'id': 'aslkjb'}
+    tags_list = Flickr.create_tags_list(data)
+    assert not tags_list
+
+
+def test_create_tags_list_returns_falsy_empty_tags():
+    data = {'id': 'aslkjb', 'tags': ''}
+    tags_list = Flickr.create_tags_list(data)
+    assert not tags_list

--- a/src/providers/api/test_Flickr.py
+++ b/src/providers/api/test_Flickr.py
@@ -2,7 +2,7 @@ import Flickr
 from datetime import datetime
 import os
 
-def test_getMetaData(monkeypatch):
+def test_process_images(monkeypatch):
     cur_time = datetime.strptime('2019-12-01', '%Y-%m-%d')
     nxt_time = datetime.strptime('2019-12-02', '%Y-%m-%d')
     def mockresult(a_url):
@@ -69,8 +69,8 @@ def test_getMetaData(monkeypatch):
         }
     tmp_directory = '/tmp/'
     output_filename = 'flickr_test.tsv'
-    monkeypatch.setattr(Flickr, "requestContent", mockresult)
-    monkeypatch.setattr(Flickr.writeToFile, '__defaults__', (tmp_directory,))
+    monkeypatch.setattr(Flickr.em, "requestContent", mockresult)
+    monkeypatch.setattr(Flickr.em.writeToFile, '__defaults__', (tmp_directory,))
     monkeypatch.setattr(Flickr, "FILE", output_filename)
     output_fullpath = os.path.join(tmp_directory, output_filename)
     try:
@@ -78,7 +78,7 @@ def test_getMetaData(monkeypatch):
     except:
         print("Could not delete old output.  Perhaps it does not exist yet.")
     expected_records = 2
-    actual_records = Flickr.getMetaData(cur_time, nxt_time, 'potato')
+    actual_records = Flickr.process_images(cur_time, nxt_time, 'potato')
     assert expected_records == actual_records
     expected_filestring = """123\twww.flickr.com/photos/123@N07/123\thttps://live.staticflickr.com/123_b.jpg\thttps://live.staticflickr.com/123_m.jpg\t768\t1024\t\\N\tby-nc-nd\t2.0\tTom-C photographe\twww.flickr.com/photos/123@N07\trpk 10 ans-8\t{"pub_date": "1572340565", "date_taken": "2019-09-07 16:27:59"}\t\\N\tf\tflickr\tflickr\n456\twww.flickr.com/photos/456@N04/456\thttps://live.staticflickr.com/456_b.jpg\thttps://live.staticflickr.com/456_m.jpg\t1024\t768\t\\N\tby-nc-nd\t2.0\tRADIOfotoGRAFIANDO\twww.flickr.com/photos/456@N04\t233 Ordesa sept 2019\t{"pub_date": "1571326372", "date_taken": "2019-09-07 16:26:44", "description": "OLYMPUS DIGITAL CAMERA"}\t[{"name": "amarilla", "provider": "flickr"}]\tf\tflickr\tflickr\n"""
     with open(output_fullpath) as f:
@@ -86,7 +86,139 @@ def test_getMetaData(monkeypatch):
     assert expected_filestring == actual_filestring
 
 
-def test_extractData_returns_Nonetype_if_no_image():
+def test_process_images_handles_missing_required_info(monkeypatch):
+    cur_time = datetime.strptime('2019-12-01', '%Y-%m-%d')
+    nxt_time = datetime.strptime('2019-12-02', '%Y-%m-%d')
+    def mockresult(a_url):
+        return {
+            "photos": {
+                "page": 1,
+                "pages": 1,
+                "perpage": 500,
+                "total": "2",
+                "photo": [
+                    {
+                        "id": "123",
+                        "owner": "123@N07",
+                        "title": "rpk 10 ans-8",
+                        "license": "3",
+                        "description": {
+                            "_content": ""
+                        },
+                        "dateupload": "1572340565",
+                        "datetaken": "2019-09-07 16:27:59",
+                        "ownername": "Tom-C photographe",
+                        "tags": "",
+                        "url_t": "https://live.staticflickr.com/123_t.jpg",
+                        "height_t": 100,
+                        "width_t": 75,
+                        "url_s": "https://live.staticflickr.com/123_m.jpg",
+                        "height_s": 240,
+                        "width_s": 180,
+                        "url_m": "https://live.staticflickr.com/123.jpg",
+                        "height_m": 500,
+                        "width_m": 375,
+                        "url_l": "https://live.staticflickr.com/123_b.jpg",
+                        "height_l": 1024,
+                        "width_l": 768
+                    },
+                    {
+                        "id": "456",
+                        "owner": "456@N04",
+                        "title": "233 Ordesa sept 2019",
+                        "description": {
+                            "_content": "OLYMPUS DIGITAL CAMERA"
+                        },
+                        "dateupload": "1571326372",
+                        "datetaken": "2019-09-07 16:26:44",
+                        "ownername": "RADIOfotoGRAFIANDO",
+                        "tags": "amarilla",
+                        "url_t": "https://live.staticflickr.com/456_t.jpg",
+                        "height_t": 75,
+                        "width_t": 100,
+                        "url_s": "https://live.staticflickr.com/456_m.jpg",
+                        "height_s": 180,
+                        "width_s": 240,
+                        "url_m": "https://live.staticflickr.com/456.jpg",
+                        "height_m": 375,
+                        "width_m": 500,
+                        "url_l": "https://live.staticflickr.com/456_b.jpg",
+                        "height_l": 768,
+                        "width_l": 1024
+                    },
+                ]
+            },
+            "stat": "ok"
+        }
+    tmp_directory = '/tmp/'
+    output_filename = 'flickr_test.tsv'
+    monkeypatch.setattr(Flickr.em, "requestContent", mockresult)
+    monkeypatch.setattr(Flickr.em.writeToFile, '__defaults__', (tmp_directory,))
+    monkeypatch.setattr(Flickr, "FILE", output_filename)
+    output_fullpath = os.path.join(tmp_directory, output_filename)
+    try:
+        os.remove(output_fullpath)
+    except:
+        print("Could not delete old output.  Perhaps it does not exist yet.")
+    expected_records = 1
+    actual_records = Flickr.process_images(cur_time, nxt_time, 'potato')
+    assert expected_records == actual_records
+    expected_filestring = """123\twww.flickr.com/photos/123@N07/123\thttps://live.staticflickr.com/123_b.jpg\thttps://live.staticflickr.com/123_m.jpg\t768\t1024\t\\N\tby-nc-nd\t2.0\tTom-C photographe\twww.flickr.com/photos/123@N07\trpk 10 ans-8\t{"pub_date": "1572340565", "date_taken": "2019-09-07 16:27:59"}\t\\N\tf\tflickr\tflickr\n"""
+    with open(output_fullpath) as f:
+        actual_filestring = f.read()
+    assert expected_filestring == actual_filestring
+
+
+def test_process_images_handles_empty_json(monkeypatch):
+    cur_time = datetime.strptime('2019-12-01', '%Y-%m-%d')
+    nxt_time = datetime.strptime('2019-12-02', '%Y-%m-%d')
+    def mockresult(a_url):
+        return {}
+    monkeypatch.setattr(Flickr.em, "requestContent", mockresult)
+    expected_records = 0
+    actual_records = Flickr.process_images(cur_time, nxt_time, 'potato')
+    assert expected_records == actual_records
+
+
+def test_process_images_handles_Nonetype(monkeypatch):
+    cur_time = datetime.strptime('2019-12-01', '%Y-%m-%d')
+    nxt_time = datetime.strptime('2019-12-02', '%Y-%m-%d')
+    def mockresult(a_url):
+        return None
+    expected_records = 0
+    actual_records = Flickr.process_images(cur_time, nxt_time, 'potato')
+    assert expected_records == actual_records
+
+
+def test_construct_api_query_string_default():
+    cur_time = datetime.strptime('2019-12-01', '%Y-%m-%d')
+    nxt_time = datetime.strptime('2019-12-02', '%Y-%m-%d')
+    actual_url = Flickr.construct_api_query_string(
+        cur_time,
+        nxt_time,
+        3,
+        1
+    )
+    expected_url = 'https://api.flickr.com/services/rest/?method=flickr.photos.search&api_key=notset&min_upload_date=2019-12-01 00:00:00&max_upload_date=2019-12-02 00:00:00&license=3&media=photos&content_type=1&extras=description,license,date_upload,date_taken,owner_name,tags,o_dims,url_t,url_s,url_m,url_l&per_page=500&format=json&nojsoncallback=1&page=1'
+    assert actual_url == expected_url
+
+
+def test_construct_api_query_string_with_switch():
+    cur_time = datetime.strptime('2019-12-01', '%Y-%m-%d')
+    nxt_time = datetime.strptime('2019-12-02', '%Y-%m-%d')
+    actual_url = Flickr.construct_api_query_string(
+        cur_time,
+        nxt_time,
+        3,
+        1,
+        switch_date=True
+    )
+    expected_url = 'https://api.flickr.com/services/rest/?method=flickr.photos.search&api_key=notset&min_taken_date=2019-12-01 00:00:00&max_taken_date=2019-12-02 00:00:00&license=3&media=photos&content_type=1&extras=description,license,date_upload,date_taken,owner_name,tags,o_dims,url_t,url_s,url_m,url_l&per_page=500&format=json&nojsoncallback=1&page=1'
+    assert actual_url == expected_url
+
+
+
+def test_extract_data_returns_Nonetype_if_no_image():
     data = {
         "id": "456",
         "owner": "456@N04",
@@ -103,7 +235,7 @@ def test_extractData_returns_Nonetype_if_no_image():
         "height_t": 75,
         "width_t": 100,
     }
-    actual_row = Flickr.extractData(data)
+    actual_row = Flickr.extract_data(data)
     expect_row = None
     assert expect_row == actual_row
 
@@ -214,7 +346,7 @@ def test_get_image_url_falls_to_small_tuple():
     assert expect_tuple == actual_tuple
 
 
-def test_extractData_returns_Nonetype_when_no_license():
+def test_extract_data_returns_Nonetype_when_no_license():
     data = {
         "id": "456",
         "owner": "456@N04",
@@ -233,7 +365,7 @@ def test_extractData_returns_Nonetype_when_no_license():
         "height_l": 768,
         "width_l": 1024
     }
-    actual_row = Flickr.extractData(data)
+    actual_row = Flickr.extract_data(data)
     expect_row = None
     assert expect_row == actual_row
 


### PR DESCRIPTION
Also, refactor/cleanup a bit of Flickr.py, increase test coverage

<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Related to #204 
## Description
<!-- Add your description below. -->

This PR has a new row-list-writing function (i.e., it creates a list of strings in the correct order for the rows output by each api provider script.  The already-existing writer function `writeToFile` then writes a list of these rows to a .tsv file.  This PR also shows a general direction for refactoring the API provider scripts.  Finally, it adds some test coverage, both of new functionality, and a bit of the old functionality.


## Other information
<!-- Add any other information below or delete the "Other Information" line entirely. -->

## Checklist
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] I added tests for the changes I made (if applicable).
- [X] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
