### PR TITLE
Sanitize json values before dumping to json string

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/modules/etlMods.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/modules/etlMods.py
@@ -1,23 +1,53 @@
+import argparse
+import json
 import logging
 import os
-import re
-import requests
-import time
-import json
-import argparse
 import random
-from datetime import datetime, timedelta
+import re
 import sys
+import time
+from datetime import datetime, timedelta
 from urllib.parse import urlparse
 
+import requests
+
 PATH = os.environ['OUTPUT_DIR']
+
+
+def _sanitize_json_values(
+        unknown_input,
+        recursion_limit=100,
+    ):
+    """
+    This function recursively sanitizes the non-dict values of an input
+    dictionary in preparation for dumping to JSON string.
+    """
+    input_type = type(unknown_input)
+    if input_type not in [dict, list] or recursion_limit <= 0:
+        return sanitizeString(unknown_input)
+    elif input_type == list:
+        return [
+            _sanitize_json_values(
+                item,
+                recursion_limit=recursion_limit - 1
+            )
+            for item in unknown_input
+        ]
+    else:
+        return {
+            key: _sanitize_json_values(
+                val,
+                recursion_limit=recursion_limit - 1
+            )
+            for key, val in unknown_input.items()
+        }
 
 
 def _prepare_output_string(unknown_input):
     if not unknown_input:
         return '\\N'
     elif type(unknown_input) in [dict, list]:
-        return json.dumps(unknown_input)
+        return json.dumps(_sanitize_json_values(unknown_input))
     else:
         return sanitizeString(unknown_input)
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/modules/etlMods.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/modules/etlMods.py
@@ -14,10 +14,7 @@ import requests
 PATH = os.environ['OUTPUT_DIR']
 
 
-def _sanitize_json_values(
-        unknown_input,
-        recursion_limit=100,
-    ):
+def _sanitize_json_values(unknown_input, recursion_limit=100):
     """
     This function recursively sanitizes the non-dict values of an input
     dictionary in preparation for dumping to JSON string.

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/modules/test_etlMods.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/modules/test_etlMods.py
@@ -1,44 +1,48 @@
 import etlMods
-import json
+
 
 def test_create_tsv_list_row_returns_none_if_missing_foreign_landing_url():
     expect_row = None
     actual_row = etlMods.create_tsv_list_row(
         foreign_identifier='a',
-        image_url = 'a',
-        license_ = 'abc',
-        license_version = '123'
+        image_url='a',
+        license_='abc',
+        license_version='123'
     )
     assert expect_row == actual_row
+
 
 def test_create_tsv_list_row_returns_none_if_missing_license():
     expect_row = None
     actual_row = etlMods.create_tsv_list_row(
         foreign_identifier='a',
-        image_url = 'a',
-        license_version = '123',
-        foreign_landing_url = 'www.testurl.com'
+        image_url='a',
+        license_version='123',
+        foreign_landing_url='www.testurl.com'
     )
     assert expect_row == actual_row
+
 
 def test_create_tsv_list_row_returns_none_if_missing_license_version():
     expect_row = None
     actual_row = etlMods.create_tsv_list_row(
         foreign_identifier='a',
-        image_url = 'a',
-        license_ = 'abc',
-        foreign_landing_url = 'www.testurl.com'
+        image_url='a',
+        license_='abc',
+        foreign_landing_url='www.testurl.com'
     )
     assert expect_row == actual_row
+
 
 def test_create_tsv_list_row_returns_none_if_missing_image_url():
     expect_row = None
     actual_row = etlMods.create_tsv_list_row(
         foreign_identifier='a',
-        foreign_landing_url = 'www.testurl.com',
-        license_ = 'abc'
+        foreign_landing_url='www.testurl.com',
+        license_='abc'
     )
     assert expect_row == actual_row
+
 
 def test_create_tsv_list_row_casts_to_strings():
     meta_data = {'key1': 'value1', 'key2': 'value2'}
@@ -50,14 +54,14 @@ def test_create_tsv_list_row_casts_to_strings():
     width = 102314
 
     actual_row = etlMods.create_tsv_list_row(
-        foreign_landing_url = 'www.testurl.comk',
-        image_url = 'a',
-        license_ = 'abc',
-        license_version = '234',
-        width = width,
-        height = height,
-        meta_data = meta_data,
-        tags = tags
+        foreign_landing_url='www.testurl.comk',
+        image_url='a',
+        license_='abc',
+        license_version='234',
+        width=width,
+        height=height,
+        meta_data=meta_data,
+        tags=tags
     )
     assert all([type(element) == str for element in actual_row])
 
@@ -67,12 +71,12 @@ def test_create_tsv_list_row_handles_empty_dict_and_tags():
     tags = []
 
     actual_row = etlMods.create_tsv_list_row(
-        foreign_landing_url = 'www.testurl.comk',
-        image_url = 'a',
-        license_ = 'abc',
-        license_version = '123',
-        meta_data = meta_data,
-        tags = tags
+        foreign_landing_url='www.testurl.comk',
+        image_url='a',
+        license_='abc',
+        license_version='123',
+        meta_data=meta_data,
+        tags=tags
     )
     actual_meta_data, actual_tags = actual_row[12], actual_row[13]
     expect_meta_data, expect_tags = '\\N', '\\N'
@@ -85,6 +89,7 @@ def test_create_tsv_list_row_turns_empty_into_nullchar():
         'foreign_landing_url': 'landing_page.com',
         'image_url': 'imageurl.com',
         'license_': 'testlicense',
+        'license_version': '1.0'
     }
     args_dict = {
         'foreign_identifier': None,
@@ -92,7 +97,6 @@ def test_create_tsv_list_row_turns_empty_into_nullchar():
         'width': None,
         'height': None,
         'filesize': None,
-        'license_version': None,
         'creator': None,
         'creator_url': None,
         'title': None,
@@ -116,7 +120,7 @@ def test_create_tsv_list_row_turns_empty_into_nullchar():
         '\\N',
         '\\N',
         'testlicense',
-        '\\N',
+        '1.0',
         '\\N',
         '\\N',
         '\\N',
@@ -126,6 +130,7 @@ def test_create_tsv_list_row_turns_empty_into_nullchar():
         '\\N',
         '\\N'
     ]
+    assert actual_row == expect_row
 
 
 def test_create_tsv_list_row_properly_places_entries():
@@ -133,13 +138,13 @@ def test_create_tsv_list_row_properly_places_entries():
         'foreign_landing_url': 'landing_page.com',
         'image_url': 'imageurl.com',
         'license_': 'testlicense',
+        'license_version': '1.0',
     }
     args_dict = {
         'foreign_identifier': 'foreign_id',
         'thumbnail': 'thumbnail.com',
         'width': 200,
         'height': 500,
-        'license_version': '1.0',
         'creator': 'tyler',
         'creator_url': 'creatorurl.com',
         'title': 'agreatpicture',
@@ -174,3 +179,127 @@ def test_create_tsv_list_row_properly_places_entries():
         'testing'
     ]
     assert expect_row == actual_row
+
+
+def test_create_tsv_row_sanitizes_dicts_and_lists(monkeypatch):
+    def mock_sanitize_json_values(some_json):
+        return 'SANITIZED'
+    monkeypatch.setattr(
+        etlMods,
+        '_sanitize_json_values',
+        mock_sanitize_json_values
+    )
+    actual_row = etlMods.create_tsv_list_row(
+        foreign_landing_url='landing_page.com',
+        image_url='imageurl.com',
+        license_='testlicense',
+        license_version='1.0',
+        meta_data={"key1": "val1"},
+        tags=["item", "item2"]
+    )
+    expect_row = [
+        '\\N',
+        'landing_page.com',
+        'imageurl.com',
+        '\\N',
+        '\\N',
+        '\\N',
+        '\\N',
+        'testlicense',
+        '1.0',
+        '\\N',
+        '\\N',
+        '\\N',
+        '"SANITIZED"',
+        '"SANITIZED"',
+        'f',
+        '\\N',
+        '\\N'
+    ]
+    print(actual_row)
+    assert expect_row == actual_row
+
+
+def test_sanitize_json_values_handles_flat_dict(monkeypatch):
+    def mock_sanitizeString(some_string):
+        return some_string + ' sanitized'
+    monkeypatch.setattr(etlMods, 'sanitizeString', mock_sanitizeString)
+    given_dict = {'key1': 'val1', 'key2': 'val2'}
+    actual_dict = etlMods._sanitize_json_values(given_dict)
+    expect_dict = {'key1': 'val1 sanitized', 'key2': 'val2 sanitized'}
+    assert expect_dict == actual_dict
+
+
+def test_sanitize_json_values_handles_nested_dict(monkeypatch):
+    def mock_sanitizeString(some_string):
+        return some_string + ' sanitized'
+    monkeypatch.setattr(etlMods, 'sanitizeString', mock_sanitizeString)
+    given_dict = {'key1': 'val1', 'key2': {'key3': 'val3'}}
+    actual_dict = etlMods._sanitize_json_values(given_dict)
+    expect_dict = {
+        'key1': 'val1 sanitized', 'key2': {'key3': 'val3 sanitized'}
+    }
+    assert expect_dict == actual_dict
+
+
+def test_sanitize_json_values_handles_dict_containing_list(monkeypatch):
+    def mock_sanitizeString(some_string):
+        return some_string + ' sanitized'
+    monkeypatch.setattr(etlMods, 'sanitizeString', mock_sanitizeString)
+    given_dict = {'key1': 'val1', 'key2': ['item1', 'item2']}
+    actual_dict = etlMods._sanitize_json_values(given_dict)
+    expect_dict = {
+        'key1': 'val1 sanitized',
+        'key2': ['item1 sanitized', 'item2 sanitized']
+    }
+    assert expect_dict == actual_dict
+
+
+def test_sanitize_json_values_handles_list_of_str(monkeypatch):
+    def mock_sanitizeString(some_string):
+        return some_string + ' sanitized'
+    monkeypatch.setattr(etlMods, 'sanitizeString', mock_sanitizeString)
+    given_list = ['item1', 'item2']
+    actual_list = etlMods._sanitize_json_values(given_list)
+    expect_list = ['item1 sanitized', 'item2 sanitized']
+    assert expect_list == actual_list
+
+
+def test_sanitize_json_values_handles_list_of_list(monkeypatch):
+    def mock_sanitizeString(some_string):
+        return some_string + ' sanitized'
+    monkeypatch.setattr(etlMods, 'sanitizeString', mock_sanitizeString)
+    given_list = ['item1', ['item2', ['item3'], 'item4'], 'item5']
+    actual_list = etlMods._sanitize_json_values(given_list)
+    expect_list = [
+        'item1 sanitized', [
+            'item2 sanitized', [
+                'item3 sanitized'
+            ], 'item4 sanitized'
+        ], 'item5 sanitized'
+    ]
+    assert expect_list == actual_list
+
+
+def test_sanitize_json_values_handles_list_of_dict(monkeypatch):
+    def mock_sanitizeString(some_string):
+        return some_string + ' sanitized'
+    monkeypatch.setattr(etlMods, 'sanitizeString', mock_sanitizeString)
+    given_list = [
+        {'name': 'valuea', 'provider': 'valueb'},
+        {'name': 'aname', 'provider': 'aprovider'}
+    ]
+    actual_list = etlMods._sanitize_json_values(given_list)
+    expect_list = [
+        {'name': 'valuea sanitized', 'provider': 'valueb sanitized'},
+        {'name': 'aname sanitized', 'provider': 'aprovider sanitized'}
+    ]
+    assert expect_list == actual_list
+
+
+def test_sanitize_json_values_does_not_over_recurse():
+    L = []
+    L.extend([L])
+    actual_list = etlMods._sanitize_json_values(L, recursion_limit=3)
+    expect_list = [[['[[...]]']]]
+    assert actual_list == expect_list


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #232 

## Description
<!-- Add your description below. -->
in `src/cc_catalog_airflow/dags/provider_api_scripts/modules/etlMods.py`, we have a function that creates lists of strings which are eventually made into `.tsv` rows.  There is apparently a difference in the way that python and PostgreSQL escape double quotes within strings.  This is relevant in the case of json fields in the `.tsv`.  Now, there is a new function `_sanitize_json_values` in `etlMods.py` that recurses through arbitrary lists, dictionaries, lists of dictionaries, dictionaries of lists, and the like, and sanitizes all bottom-level values (or items in the case of lists).  This avoids the double-quote problem, and likely others.

## Checklist
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
