### PR TITLE
schedule separate DAGs to run in place of dailyWorkflow.py

### DIFF
--- a/src/cc_catalog_airflow/dags/util/config.py
+++ b/src/cc_catalog_airflow/dags/util/config.py
@@ -34,15 +34,19 @@ API_SCRIPT_PATH = os.path.join(AIRFLOW_HOME, 'dags/provider_api_scripts')
 DAG_VARIABLES = {
     'flickr': {
         SCRIPT: os.path.join(API_SCRIPT_PATH, 'Flickr.py'),
+        CRONTAB_STR: '0 * * * *'
     },
     'met_museum': {
         SCRIPT: os.path.join(API_SCRIPT_PATH, 'MetMuseum.py'),
+        CRONTAB_STR: '0 9 * * *'
     },
     'phylo_pic': {
         SCRIPT: os.path.join(API_SCRIPT_PATH, 'PhyloPic.py'),
+        CRONTAB_STR: '0 11 * * *'
     },
     'thingiverse': {
         SCRIPT: os.path.join(API_SCRIPT_PATH, 'Thingiverse.py'),
+        CRONTAB_STR: '0 7 * * *'
     },
     'wikimedia_commons': {
         SCRIPT: os.path.join(API_SCRIPT_PATH, 'WikimediaCommons.py'),


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #239 

## Description
<!-- Add your description below. -->

The only code changes here are to add appropriate crontab strings to run the various Apache Airflow DAGs (Directed Acyclic Graphs) at the appropriate times.  

## Checklist
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
