### PR TITLE
WIP: Rewriting RawPixel Provider API Script using new ImageStore class

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/rawpixel.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/rawpixel.py
@@ -1,0 +1,171 @@
+from common.storage.image import ImageStore
+from common.requester import DelayedRequester
+import requests
+import time
+import logging
+import re
+import json
+from urllib.parse import urlparse, parse_qs
+
+DELAY   = 1.0 #time delay (in seconds)
+PROVIDER = 'rawpixel'
+FILE    = 'rawpixel_{}.tsv'.format(int(time.time()))
+
+logging.basicConfig(format='%(asctime)s: [%(levelname)s - RawPixel API] =======> %(message)s', level=logging.INFO)
+
+delayed_requester = DelayedRequester(DELAY)
+image_store = ImageStore(provider=PROVIDER,output_file=FILE)
+
+def sanitizeString(_data):
+    if _data is None:
+        return ''
+    else:
+        _data = str(_data)
+
+    _data       = _data.strip()
+    _data       = _data.replace('"', "'")
+    _data       = re.sub(r'\n|\r', ' ', _data)
+    #_data      = re.escape(_data)
+
+    backspaces  = re.compile('\b+')
+    _data       = backspaces.sub('', _data)
+    _data       = _data.replace('\\', '\\\\')
+
+    return re.sub(r'\s+', ' ', _data)
+
+def requestContent(_url, _query_params=None, _headers=None):
+    logging.info('Processing request: {}'.format(_url))
+
+    response = delayed_requester.get(
+        _url,
+        params=_query_params,
+        headers=_headers
+    )
+
+    try:
+        if response.status_code == requests.codes.ok:
+            return response.json()
+        else:
+            logging.warning('Unable to request URL: {}. Status code: {}'.format(url, response.status_code))
+            return None
+
+    except Exception as e:
+        logging.error('There was an error with the request.')
+        logging.info('{}: {}'.format(type(e).__name__, e))
+        return None
+
+def getImageList(_page=1):
+    endpoint    = 'https://api.rawpixel.com/api/v1/search'
+    query_params =  {
+        'freecc0': 1,
+        'html': 0,
+        'page': _page
+    }
+    request = requestContent(endpoint, _query_params=query_params)
+
+    if request.get('results'):
+        return [request.get('total'), request.get('results')]
+
+    else:
+        return [None, None]
+
+def _process_image_data(_image):
+    startTime   = time.time()
+
+    #verify the license and extract the metadata
+    foreignID   = ''
+    foreignURL  = ''
+    imgURL      = ''
+    width       = ''
+    height      = ''
+    thumbnail   = ''
+    tags        = ''
+    title       = ''
+    owner       = ''
+    license     = 'cc0'
+    version     = '1.0'
+    tags        = {}
+
+    if _image.get('freecc0'):
+        #get the image identifier
+        foreignID = _image.get('id', '')
+
+        #get the landing page
+        foreignURL = _image.get('url')
+
+        if not foreignURL:
+            logging.warning('Landing page not detected for image ID: {}'.format(foreignID))
+            return None
+
+        imgURL = _image.get('image_opengraph')
+        if imgURL:
+            #extract the dimensions from the query params because the dimensions in the metadata are at times inconsistent with the rescaled images
+            queryParams = urlparse(imgURL)
+            width       = parse_qs(queryParams.query).get('w', [])[0] #width
+            height      = parse_qs(queryParams.query).get('h', [])[0] #height
+
+            thumbnail   = _image.get('image_400', '')
+        else:
+            logging.warning('Image not detected in URL: {}'.format(foreignURL))
+            return None
+
+        title = sanitizeString(_image.get('image_title', ''))
+
+        owner = sanitizeString(_image.get('artists', ''))
+        owner = owner.replace('(Source)', '').strip()
+
+        keywords        = _image.get('keywords_raw')
+        if keywords:
+            keywordList = keywords.split(',')
+            keywordList = list(filter(lambda word: word.strip() not in ['cc0', 'creative commons', 'creative commons 0'], keywordList))
+
+            tags        = [{'name': sanitizeString(tag), 'provider': 'rawpixel'} for tag in keywordList]
+
+    # TODO: How to get license_url, creator, creator_url, source?
+    return image_store.add_item(
+        foreign_landing_url=foreignURL,
+        image_url=imgURL,
+        license_=license,
+        license_version=str(version),
+        foreign_identifier=str(foreignID),
+        width=str(width) if width else None,
+        height=str(height) if height else None,
+        title=title if title else None,
+        raw_tags=json.dumps(tags, ensure_ascii=False) if bool(tags) else None,
+    )
+
+def main():
+    page    = 1
+    imgCtr  = 0
+    isValid = True
+
+    logging.info('Begin: RawPixel API requests')
+
+    total, result = getImageList(page)
+
+    while (imgCtr < total) and isValid:
+        logging.info('Processing page: {}'.format(page))
+
+        startTime = time.time()
+        for img in result:
+            total_images = _process_image_data(img)
+            imgCtr = total_images if total_images else imgCtr
+
+        total_images = image_store.commit()
+
+        page += 1
+        total, result = getImageList(page)
+
+        if not result:
+            isValid = False
+
+        if not total:
+            total = 0
+            isValid = False
+
+    logging.info('Total images: {}'.format(imgCtr))
+    logging.info('Terminated!')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Fixes #256 
(Work In Progress)

## Description
Rewrote new script `src/cc_catalog_airflow/dags/provider_api_scripts/rawpixel.py` . Uses `ImageStore` and `DelayedRequester` classes. 


## Other information
TODOs - 
- [ ] Add Test suite
- [ ] Use of date Parameter

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
