### PR TITLE
delete extraneous requests.get outside of try/except block

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/common/requester.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/common/requester.py
@@ -36,7 +36,6 @@ class DelayedRequester:
         logger.info(f'Using query parameters {params}')
         logger.info(f'Using headers {kwargs.get("headers")}')
         self._delay_processing()
-        response = requests.get(url, params, **kwargs)
         self._last_request = time.time()
         try:
             response = requests.get(url, params=params, **kwargs)

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/common/test_requester.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/common/test_requester.py
@@ -18,3 +18,13 @@ def test_get_waits_before_getting(monkeypatch):
     start = time.time()
     dq.get('https://google.com')
     assert time.time() - start >= delay
+
+
+def test_get_handles_exception(monkeypatch):
+    def mock_requests_get(url, params, **kwargs):
+        raise requests.exceptions.ReadTimeout('test timeout!')
+
+    monkeypatch.setattr(requester.requests, 'get', mock_requests_get)
+
+    dq = requester.DelayedRequester(1)
+    dq.get('https://google.com/')


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #258 
## Description
<!-- Add your description below. -->
This PR deletes an extraneous call to `requests.get`.  It was intended to be within the try/except block of the `requester.DelayedRequester.get` method, but got left outside.  This was causing a bug where (common) Timeout Exceptions from `requests.get` were not handled as expected.

## Checklist
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
