### PR TITLE
Improve Wikimedia Timeout Exception handling

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
@@ -4,6 +4,8 @@ import os
 import requests
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 import wikimedia_commons as wmc
 
 RESOURCES = os.path.join(
@@ -238,7 +240,8 @@ def test_get_response_json_retries_with_none_response():
             'get',
             return_value=None
     ) as mock_get:
-        wmc._get_response_json({}, retries=2)
+        with pytest.raises(Exception):
+            assert wmc._get_response_json({}, retries=2)
 
     assert mock_get.call_count == 3
 
@@ -252,7 +255,8 @@ def test_get_response_json_retries_with_non_ok():
             'get',
             return_value=r
     ) as mock_get:
-        wmc._get_response_json({}, retries=2)
+        with pytest.raises(Exception):
+            assert wmc._get_response_json({}, retries=2)
 
     assert mock_get.call_count == 3
 
@@ -266,7 +270,8 @@ def test_get_response_json_retries_with_error_json():
             'get',
             return_value=r
     ) as mock_get:
-        wmc._get_response_json({}, retries=2)
+        with pytest.raises(Exception):
+            assert wmc._get_response_json({}, retries=2)
 
     assert mock_get.call_count == 3
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -228,7 +228,7 @@ def _get_response_json(
         endpoint,
         params=query_params,
         headers=request_headers,
-        timeout=15
+        timeout=60
     )
     if response is not None and response.status_code == 200:
         try:

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -221,8 +221,8 @@ def _get_response_json(
     response_json = None
 
     if retries < 0:
-        logger.warning('No retries remaining.  Returning Nonetype.')
-        return response_json
+        logger.error('No retries remaining.  Failure.')
+        raise Exception('Retries exceeded')
 
     response = delayed_requester.get(
         endpoint,


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #260 

## Description
<!-- Add your description below. -->
This PR increases the timeout length to 60 seconds.  This should help keep the WMC script from needing to retry requests as often.  Further, when we hit the retry limit, we now raise an exception.  This will make the failure known to Apache Airflow, and we'll see a red dot on the interface (thereby warning us that we need to rerun the script for that day).

## Checklist
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
