### PR TITLE
use has_image parameter in Cleveland Museum script

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/ClevelandMuseum.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/ClevelandMuseum.py
@@ -43,23 +43,17 @@ def getMetaData(_data):
     #get the image url and dimension
     imgInfo     = _data.get('images')
 
-    if imgInfo and imgInfo.get('web'):
+    if imgInfo.get('web'):
         imgURL  = imgInfo.get('web', {}).get('url', None)
         key     = 'web'
 
-    elif imgInfo and imgInfo.get('print'):
+    elif imgInfo.get('print'):
         imgURL  = imgInfo.get('print', {}).get('url', None)
         key     = 'print'
 
-    elif imgInfo and imgInfo.get('full'):
+    elif imgInfo.get('full'):
         imgURL  = imgInfo.get('full', {}).get('url', None)
         key     = 'full'
-
-
-    if (not imgInfo) or (not imgURL):
-        logging.warning('Image not detected in url {}'.format(foreignURL))
-        return None
-
 
     if imgURL and key:
         width   = imgInfo[key]['width']
@@ -129,7 +123,7 @@ def main():
 
     while isValid:
         startTime   = time.time()
-        endpoint    = 'http://openaccess-api.clevelandart.org/api/artworks/?cc0=1&limit={0}&skip={1}'.format(LIMIT, offset)
+        endpoint    = 'http://openaccess-api.clevelandart.org/api/artworks/?cc0=1&has_image=1&limit={0}&skip={1}'.format(LIMIT, offset)  ##############
         batch       = requestContent(endpoint)
 
         if batch and ('data' in batch):


### PR DESCRIPTION
Fixes #205 

## Description
The Cleveland Museum script now makes use of the `has_image` parameter of the API and the logic to skip pieces of data without images is not required anymore.

## Other information
I added `has_image` parameter to the endpoint.
I removed the part where we check if an image exists in the data or not, since only the data with images is received as response.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
