### PR TITLE
Refactor flickr provider API script's _get_image_list to use 'max_tries' instead of 'retries'

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/ClevelandMuseum.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/ClevelandMuseum.py
@@ -123,7 +123,7 @@ def main():
 
     while isValid:
         startTime   = time.time()
-        endpoint    = 'http://openaccess-api.clevelandart.org/api/artworks/?cc0=1&has_image=1&limit={0}&skip={1}'.format(LIMIT, offset)  ##############
+        endpoint    = 'http://openaccess-api.clevelandart.org/api/artworks/?cc0=1&has_image=1&limit={0}&skip={1}'.format(LIMIT, offset)
         batch       = requestContent(endpoint)
 
         if batch and ('data' in batch):

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/flickr.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/flickr.py
@@ -124,7 +124,7 @@ def _get_image_list(
         endpoint=ENDPOINT,
         max_tries=6  # one original try, plus 5 retries
 ):
-    for try_number in range(max_tries-1,-1,-1):
+    for try_number in range(max_tries):
         query_param_dict = _build_query_param_dict(
             start_timestamp,
             end_timestamp,
@@ -143,7 +143,8 @@ def _get_image_list(
         if (image_list is not None) or (total_pages is not None):
             break
 
-    if try_number == 0 and ((image_list is None) or (total_pages is None)):
+    if try_number == max_tries - 1 and (
+            (image_list is None) or (total_pages is None)):
         logger.warning('No more tries remaining.  Returning Nonetypes.')
         return None, None
     else:

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/flickr.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/flickr.py
@@ -122,38 +122,32 @@ def _get_image_list(
         date_type,
         page_number,
         endpoint=ENDPOINT,
-        retries=5
+        tries=6  # one original try, plus 5 retries
 ):
-    query_param_dict = _build_query_param_dict(
-        start_timestamp,
-        end_timestamp,
-        page_number,
-        date_type,
-    )
-
-    if retries < 0:
-        logger.warning('No retries remaining.  Returning Nonetypes.')
-        return None, None
-    else:
+    for try_number in range(tries-1,-1,-1):
+        query_param_dict = _build_query_param_dict(
+            start_timestamp,
+            end_timestamp,
+            page_number,
+            date_type,
+        )
         response = delayed_requester.get(
             endpoint,
             params=query_param_dict,
         )
 
-    logger.debug('response.status_code: {response.status_code}')
-    response_json = _extract_response_json(response)
-    image_list, total_pages = _extract_image_list_from_json(response_json)
+        logger.debug('response.status_code: {response.status_code}')
+        response_json = _extract_response_json(response)
+        image_list, total_pages = _extract_image_list_from_json(response_json)
 
-    if image_list is None or total_pages is None:
-        image_list, total_pages = _get_image_list(
-            start_timestamp,
-            end_timestamp,
-            date_type,
-            page_number,
-            retries=retries - 1
-        )
+        if (image_list is not None) or (total_pages is not None):
+            break
 
-    return image_list, total_pages
+    if try_number == 0:
+        logger.warning('No more tries remaining.  Returning Nonetypes.')
+        return None, None
+    else:
+        return image_list, total_pages
 
 
 def _extract_response_json(response):

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/flickr.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/flickr.py
@@ -143,7 +143,7 @@ def _get_image_list(
         if (image_list is not None) or (total_pages is not None):
             break
 
-    if try_number == 0:
+    if try_number == 0 and ((image_list is None) or (total_pages is None)):
         logger.warning('No more tries remaining.  Returning Nonetypes.')
         return None, None
     else:

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/flickr.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/flickr.py
@@ -140,12 +140,12 @@ def _get_image_list(
         response_json = _extract_response_json(response)
         image_list, total_pages = _extract_image_list_from_json(response_json)
 
-        if (image_list is not None) or (total_pages is not None):
+        if (image_list is not None) and (total_pages is not None):
             break
 
     if try_number == max_tries - 1 and (
             (image_list is None) or (total_pages is None)):
-        logger.warning('No more tries remaining.  Returning Nonetypes.')
+        logger.warning('No more tries remaining. Returning Nonetypes.')
         return None, None
     else:
         return image_list, total_pages

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/flickr.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/flickr.py
@@ -122,9 +122,9 @@ def _get_image_list(
         date_type,
         page_number,
         endpoint=ENDPOINT,
-        tries=6  # one original try, plus 5 retries
+        max_tries=6  # one original try, plus 5 retries
 ):
-    for try_number in range(tries-1,-1,-1):
+    for try_number in range(max_tries-1,-1,-1):
         query_param_dict = _build_query_param_dict(
             start_timestamp,
             end_timestamp,

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_flickr.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_flickr.py
@@ -47,7 +47,7 @@ def test_get_image_list_retries_with_none_response():
             'get',
             return_value=None
     ) as mock_get:
-        flickr._get_image_list('1234', '5678', 'test', 4, retries=2)
+        flickr._get_image_list('1234', '5678', 'test', 4, tries=3)
 
     assert mock_get.call_count == 3
 
@@ -62,7 +62,7 @@ def test_get_image_list_retries_with_non_ok_response():
             'get',
             return_value=r
     ) as mock_get:
-        flickr._get_image_list('1234', '5678', 'test', 4, retries=2)
+        flickr._get_image_list('1234', '5678', 'test', 4, tries=3)
 
     assert mock_get.call_count == 3
 
@@ -78,7 +78,7 @@ def test_get_image_list_with_realistic_response():
             return_value=r
     ) as mock_get:
         image_list, total_pages = flickr._get_image_list(
-            '1234', '5678', 'test', 4, retries=2
+            '1234', '5678', 'test', 4, tries=3
         )
     expect_image_list = _get_resource_json('flickr_example_photo_list.json')
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_flickr.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_flickr.py
@@ -47,7 +47,7 @@ def test_get_image_list_retries_with_none_response():
             'get',
             return_value=None
     ) as mock_get:
-        flickr._get_image_list('1234', '5678', 'test', 4, tries=3)
+        flickr._get_image_list('1234', '5678', 'test', 4, max_tries=3)
 
     assert mock_get.call_count == 3
 
@@ -62,7 +62,7 @@ def test_get_image_list_retries_with_non_ok_response():
             'get',
             return_value=r
     ) as mock_get:
-        flickr._get_image_list('1234', '5678', 'test', 4, tries=3)
+        flickr._get_image_list('1234', '5678', 'test', 4, max_tries=3)
 
     assert mock_get.call_count == 3
 
@@ -78,7 +78,7 @@ def test_get_image_list_with_realistic_response():
             return_value=r
     ) as mock_get:
         image_list, total_pages = flickr._get_image_list(
-            '1234', '5678', 'test', 4, tries=3
+            '1234', '5678', 'test', 4, max_tries=3
         )
     expect_image_list = _get_resource_json('flickr_example_photo_list.json')
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_flickr.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_flickr.py
@@ -67,6 +67,23 @@ def test_get_image_list_retries_with_non_ok_response():
     assert mock_get.call_count == 3
 
 
+def test_get_image_list_with_partial_response():
+    response_json = _get_resource_json('total_pages_but_no_image_list.json')
+    r = requests.Response()
+    r.status_code = 200
+    r.json = MagicMock(return_value=response_json)
+    with patch.object(
+            flickr.delayed_requester,
+            'get',
+            return_value=r
+    ) as mock_get:
+        image_list, total_pages = flickr._get_image_list(
+            '1234', '5678', 'test', 4, max_tries=3
+        )
+
+    assert mock_get.call_count == 3
+
+
 def test_get_image_list_with_realistic_response():
     response_json = _get_resource_json('flickr_example_pretty.json')
     r = requests.Response()

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/flickr/total_pages_but_no_image_list.json
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/flickr/total_pages_but_no_image_list.json
@@ -1,0 +1,9 @@
+{
+  "photos": {
+    "page": 1,
+    "pages": 1,
+    "perpage": 500,
+    "total": "30"
+  },
+  "stat": "ok"
+}


### PR DESCRIPTION
Fixes #262 

## Description
- I've refactored the `_get_image_list` method in flickr's provider API script, which now uses `max_tries` instead to `retries` to avoid confusion. The number of tries are set as **one original try + number of retries**. 
- Instead of calling the function inside itself again till retries become 0, now it runs in a loop (specified by the number of max_tries), which breaks if image_list is or total_pages is found and not None.
- I removed an unnecessary comment in Cleveland Museum script, which I missed in my previous PR (#270).

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
