### PR TITLE
Rewrite Phylopic Provider API script using new model

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/phylopic.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/phylopic.py
@@ -36,7 +36,7 @@ delayed_requester = requester.DelayedRequester(DELAY)
 image_store = image.ImageStore(provider=PROVIDER)
 
 
-def main(date):
+def main(date='all'):
     """
     This script pulls the data for a given date from the PhyloPic
     API, and writes it into a .TSV file to be eventually read
@@ -82,18 +82,24 @@ def _add_data_to_buffer(**args):
     for id_ in IDs:
         if id_ is not None:
             details = _get_meta_data(id_)
-
             if details is not None:
-                image_store.add_item(foreign_landing_url=details[1],
-                                     image_url=details[2],
-                                     thumbnail_url=details[3],
-                                     license_url=details[6],
-                                     width=details[4],
-                                     height=details[5],
-                                     creator=details[7],
-                                     title=details[8],
-                                     meta_data=details[9],
-                                     )
+                args = _create_args(details, id_)
+                image_store.add_item(**args)
+
+
+def _create_args(details, id_):
+    args = {'foreign_landing_url': details[1],
+            'image_url': details[2],
+            'thumbnail_url': details[3],
+            'license_url': details[6],
+            'width': details[4],
+            'height': details[5],
+            'creator': details[7],
+            'title': details[8],
+            'meta_data': details[9],
+            'foreign_identifier': id_
+            }
+    return args
 
 
 def _get_total_images():
@@ -290,15 +296,11 @@ def _get_response_json(
 
 
 if __name__ == '__main__':
-    date = 'all'
-
     parser = argparse.ArgumentParser(description='PhyloPic API Job',
                                      add_help=True)
-    parser.add_argument('--date', default=False, help='Identify all images'
+    parser.add_argument('--date', default='all', help='Identify all images'
                         ' from a particular date (YYYY-MM-DD).')
-    args = parser.parse_args()
 
-    if args.date is not False:
-        date = str(args.date)
+    date = parser.parse_args().date
 
     main(date)

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/phylopic.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/phylopic.py
@@ -1,0 +1,280 @@
+"""
+Content Provider:       PhyloPic
+
+ETL Process:            Use the API to identify all CC licensed images.
+
+Output:                 TSV file containing the image, their respective meta-data.
+
+Notes:                  http://phylopic.org/api/
+                        No rate limit specified.
+"""
+
+
+import argparse
+from datetime import datetime, timedelta
+import logging
+import json
+import time
+import lxml.html as html
+
+import common.requester as requester
+import common.storage.image as image
+
+
+logging.basicConfig(
+    format='%(asctime)s - %(name)s - %(levelname)s:  %(message)s',
+    level=logging.INFO
+)
+
+logger = logging.getLogger(__name__)
+
+
+DELAY = 5
+HOST = 'phylopic.org'
+ENDPOINT = f'http://{HOST}/api/a'
+PROVIDER = 'phylopic'
+FILE    = 'phylopic_{}.tsv'.format(int(time.time()))
+LIMIT   = 5
+
+
+delayed_requester = requester.DelayedRequester(DELAY)
+image_store = image.ImageStore(provider=PROVIDER)
+
+
+logger = logging.getLogger(__name__)
+
+
+def getTotalImages():
+    #Get the total number of PhyloPic images
+    total = 0
+    endpoint = 'http://phylopic.org/api/a/image/count'
+    request = delayed_requester.get(endpoint)
+    result = request.json()
+    #result = json.loads(result_json)
+
+    if result and result.get('success') == True:
+        total = result.get('result')
+
+    return total
+
+
+def getImageIDs(**args):
+    limit       = LIMIT
+    offset      = 0
+    endpoint    = ''
+
+    if args.get('date'):
+        # Get a list of recently updated/uploaded objects.
+        date     = args['date']
+        endpoint = 'http://phylopic.org/api/a/image/list/modified/{}'.format(date)
+
+    else:
+        # Get all images and limit the results for each request.
+        offset   = args['offset']
+        endpoint = 'http://phylopic.org/api/a/image/list/{}/{}'.format(offset, limit)
+
+    if endpoint == '':
+        logger.warning('Unable to parse endpoint: {}, args: {}'.format(endpoint, args))
+        return [None]
+
+    response = delayed_requester.get(endpoint)
+    result = response.json()
+    imageIDs = []
+
+    if result and result.get('success') == True:
+        data = list(result.get('result'))
+
+        if len(data) > 0:
+            for i in range(len(data)):
+                imageIDs.append(data[i].get('uid'))
+
+    if not imageIDs:
+        logger.warning('Content not available!')
+        return [None]
+
+    return imageIDs
+
+
+def getMetaData(_uuid):
+    logger.info('Processing UUID: {}'.format(_uuid))
+
+    startTime   = time.time()
+    baseURL     = 'http://phylopic.org'
+    license     = ''
+    version     = ''
+    imgURL      = ''
+    thumbnail   = ''
+    width       = ''
+    height      = ''
+    foreignID   = ''
+    foreignURL  = ''
+    metaData    = {}
+    creator     = ''
+    title       = ''
+
+    endpoint    = 'http://phylopic.org/api/a/image/{}?options=credit+licenseURL+pngFiles+submitted+submitter+taxa+canonicalName+string+firstName+lastName'.format(_uuid)
+    get_request = delayed_requester.get(endpoint)
+    request     = get_request.json()
+
+    if request and request.get('success') == True:
+        result  = request['result']
+
+    license_url = result.get('licenseURL')
+
+    imgInfo = result.get('pngFiles')
+    if imgInfo:
+        img = list(filter(lambda x: (int(str(x.get('width', '0'))) >= 257), imgInfo))
+        img = sorted(img, key = lambda x: x['width'],reverse=True)
+        thb = list(filter(lambda x: str(x.get('width', '')) == '256', imgInfo))
+
+
+        if img:
+            imgURL  = img[0].get('url')
+            imgURL  = '{}{}'.format(baseURL, imgURL)
+            width   = img[0].get('width')
+            height  = img[0].get('height')
+
+            if thb:
+                thumbInfo = thb[0].get('url')
+                if thumbInfo:
+                    thumbnail = '{}{}'.format(baseURL, thumbInfo)
+
+    if not imgURL:
+        logger.warning('Image not detected in url: {}/image/{}'.format(baseURL, _uuid))
+        return None
+
+    foreignID   = imgURL
+    foreignURL  = '{}/image/{}'.format(baseURL, _uuid)
+
+    firstName   = result.get('submitter', {}).get('firstName')
+    lastName    = result.get('submitter', {}).get('lastName')
+    creator     = '{} {}'.format(firstName, lastName).strip()
+
+    taxa        = result.get('taxa', [])#[0].get('canonicalName', {}).get('string')
+    taxaList    = None
+    if taxa:
+        taxa     = list(filter(lambda x: x.get('canonicalName') is not None, taxa))
+        taxaList = list(map(lambda x: x.get('canonicalName', {}).get('string', ''), taxa))
+
+
+    if taxaList:
+        title = taxaList[0]
+
+        if len(taxaList) > 1:
+            metaData['taxa'] = taxaList
+
+
+    if result.get('credit'):
+        metaData['credit_line'] = result.get('credit').strip()
+        metaData['pub_date']    = result.get('submitted').strip()
+
+
+    return [
+            foreignID, foreignURL, imgURL,
+            thumbnail if thumbnail else '\\N',
+            str(width) if width else '\\N',
+            str(height) if height else '\\N',
+            license_url,
+            creator if creator else '\\N',
+            title if title else '\\N',
+            json.dumps(metaData, ensure_ascii=False) if bool(metaData) else '\\N',
+            '\\N', 'f', 'phylopic', 'phylopic'
+        ]
+
+
+def commit_to_file_all(**args):
+    startTime = time.time()
+    IDs       = getImageIDs(**args)
+
+    if IDs:
+        for id in IDs:
+            if id is not None:
+                details = getMetaData(id)
+
+                if details is not None:
+                    image_store.add_item(foreign_landing_url=details[1],
+                                         image_url=details[2],
+                                         thumbnail_url=details[3],
+                                         license_url=details[6],
+                                         width=details[4],
+                                         height=details[5],
+                                         creator=details[7],
+                                         title=details[8],
+                                         meta_data=details[9],
+                    )
+        image_store.commit()
+        logger.info('Flushed current buffer to file.')
+
+def commit_to_file_date(**args):
+    startTime = time.time()
+    IDs       = getImageIDs(**args)
+    rounds    = len(IDs)//5 if len(IDs)%5 == 0 else len(IDs)//5 + 1
+
+    ctr = 1
+    while ctr <= len(IDs):
+        if IDs[ctr-1] is not None:
+            details = getMetaData(IDs[ctr-1])
+
+            if details is not None:
+                image_store.add_item(foreign_landing_url=details[1],
+                                     image_url=details[2],
+                                     thumbnail_url=details[3],
+                                     license_url=details[6],
+                                     width=details[4],
+                                     height=details[5],
+                                     creator=details[7],
+                                     title=details[8],
+                                     meta_data=details[9],
+                )
+
+        if ctr % LIMIT == 0:
+            # Add 5 images at a time to file
+            image_store.commit()
+            logger.info('Flushed current buffer to file.')
+        ctr += 1
+
+    image_store.commit()
+
+
+def main():
+    logger.info('Begin: PhyloPic API requests')
+    param   = None
+    offset  = 0
+
+
+    parser  = argparse.ArgumentParser(description='PhyloPic API Job', add_help=True)
+    parser.add_argument('--mode', choices=['default', 'all'],
+            help='Identify all images from the previous day [default]'
+                 ' or process the entire collection [all].')
+    parser.add_argument('--date', default=False, help='Identify all images from'
+        ' a particular date (YYYY-MM-DD).')
+    args = parser.parse_args()
+
+    if str(args.mode) == 'all':
+        logger.info('Processing all images')
+        param = {'offset': offset}
+
+        imgCtr  = getTotalImages()
+        logger.info('Total images: {}'.format(imgCtr))
+
+        while offset <= imgCtr:
+            commit_to_file_all(**param)
+            offset += LIMIT
+            param   = {'offset': offset}
+
+    elif args.date is not False:
+        param = {'date': args.date}
+        logger.info('Processing date: {}'.format(param['date']))
+        commit_to_file_date(**param)
+
+    else:
+        param = {'date': datetime.strftime(datetime.now() - timedelta(1), '%Y-%m-%d')}
+        logger.info('Processing date: {}'.format(param['date']))
+        commit_to_file_date(**param)
+
+
+    logger.info('Terminated!')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/phylopic.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/phylopic.py
@@ -3,7 +3,8 @@ Content Provider:       PhyloPic
 
 ETL Process:            Use the API to identify all CC licensed images.
 
-Output:                 TSV file containing the image, their respective meta-data.
+Output:                 TSV file containing the image,
+                        their respective meta-data.
 
 Notes:                  http://phylopic.org/api/
                         No rate limit specified.
@@ -15,7 +16,6 @@ from datetime import datetime, timedelta
 import logging
 import json
 import time
-import lxml.html as html
 
 import common.requester as requester
 import common.storage.image as image
@@ -25,7 +25,6 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s:  %(message)s',
     level=logging.INFO
 )
-
 logger = logging.getLogger(__name__)
 
 
@@ -33,163 +32,59 @@ DELAY = 5
 HOST = 'phylopic.org'
 ENDPOINT = f'http://{HOST}/api/a'
 PROVIDER = 'phylopic'
-FILE    = 'phylopic_{}.tsv'.format(int(time.time()))
-LIMIT   = 5
+FILE = 'phylopic_{}.tsv'.format(int(time.time()))
+LIMIT = 5
 
 
 delayed_requester = requester.DelayedRequester(DELAY)
 image_store = image.ImageStore(provider=PROVIDER)
 
 
-logger = logging.getLogger(__name__)
+def main(date):
+    """
+    This script pulls the data for a given date from the PhyloPic
+    API, and writes it into a .TSV file to be eventually read
+    into our DB.
 
+    Required Arguments:
 
-def getTotalImages():
-    #Get the total number of PhyloPic images
-    total = 0
-    endpoint = 'http://phylopic.org/api/a/image/count'
-    request = delayed_requester.get(endpoint)
-    result = request.json()
-    #result = json.loads(result_json)
+    date:  Date String in the form YYYY-MM-DD.  This is the date for
+           which running the script will pull data.
+    """
 
-    if result and result.get('success') == True:
-        total = result.get('result')
+    param = None
+    offset = 0
 
-    return total
+    logger.info('Begin: PhyloPic API requests')
 
+    if date == 'all':
+        logger.info('Processing all images')
+        param = {'offset': offset}
 
-def getImageIDs(**args):
-    limit       = LIMIT
-    offset      = 0
-    endpoint    = ''
+        image_count = _get_total_images()
+        logger.info('Total images: {}'.format(image_count))
 
-    if args.get('date'):
-        # Get a list of recently updated/uploaded objects.
-        date     = args['date']
-        endpoint = 'http://phylopic.org/api/a/image/list/modified/{}'.format(date)
+        while offset <= image_count:
+            _commit_to_file_all(**param)
+            offset += LIMIT
+            param = {'offset': offset}
 
     else:
-        # Get all images and limit the results for each request.
-        offset   = args['offset']
-        endpoint = 'http://phylopic.org/api/a/image/list/{}/{}'.format(offset, limit)
+        param = {'date': date}
+        logger.info('Processing date: {}'.format(date))
+        _commit_to_file_date(**param)
 
-    if endpoint == '':
-        logger.warning('Unable to parse endpoint: {}, args: {}'.format(endpoint, args))
-        return [None]
-
-    response = delayed_requester.get(endpoint)
-    result = response.json()
-    imageIDs = []
-
-    if result and result.get('success') == True:
-        data = list(result.get('result'))
-
-        if len(data) > 0:
-            for i in range(len(data)):
-                imageIDs.append(data[i].get('uid'))
-
-    if not imageIDs:
-        logger.warning('Content not available!')
-        return [None]
-
-    return imageIDs
+    logger.info('Terminated!')
 
 
-def getMetaData(_uuid):
-    logger.info('Processing UUID: {}'.format(_uuid))
-
-    startTime   = time.time()
-    baseURL     = 'http://phylopic.org'
-    license     = ''
-    version     = ''
-    imgURL      = ''
-    thumbnail   = ''
-    width       = ''
-    height      = ''
-    foreignID   = ''
-    foreignURL  = ''
-    metaData    = {}
-    creator     = ''
-    title       = ''
-
-    endpoint    = 'http://phylopic.org/api/a/image/{}?options=credit+licenseURL+pngFiles+submitted+submitter+taxa+canonicalName+string+firstName+lastName'.format(_uuid)
-    get_request = delayed_requester.get(endpoint)
-    request     = get_request.json()
-
-    if request and request.get('success') == True:
-        result  = request['result']
-
-    license_url = result.get('licenseURL')
-
-    imgInfo = result.get('pngFiles')
-    if imgInfo:
-        img = list(filter(lambda x: (int(str(x.get('width', '0'))) >= 257), imgInfo))
-        img = sorted(img, key = lambda x: x['width'],reverse=True)
-        thb = list(filter(lambda x: str(x.get('width', '')) == '256', imgInfo))
-
-
-        if img:
-            imgURL  = img[0].get('url')
-            imgURL  = '{}{}'.format(baseURL, imgURL)
-            width   = img[0].get('width')
-            height  = img[0].get('height')
-
-            if thb:
-                thumbInfo = thb[0].get('url')
-                if thumbInfo:
-                    thumbnail = '{}{}'.format(baseURL, thumbInfo)
-
-    if not imgURL:
-        logger.warning('Image not detected in url: {}/image/{}'.format(baseURL, _uuid))
-        return None
-
-    foreignID   = imgURL
-    foreignURL  = '{}/image/{}'.format(baseURL, _uuid)
-
-    firstName   = result.get('submitter', {}).get('firstName')
-    lastName    = result.get('submitter', {}).get('lastName')
-    creator     = '{} {}'.format(firstName, lastName).strip()
-
-    taxa        = result.get('taxa', [])#[0].get('canonicalName', {}).get('string')
-    taxaList    = None
-    if taxa:
-        taxa     = list(filter(lambda x: x.get('canonicalName') is not None, taxa))
-        taxaList = list(map(lambda x: x.get('canonicalName', {}).get('string', ''), taxa))
-
-
-    if taxaList:
-        title = taxaList[0]
-
-        if len(taxaList) > 1:
-            metaData['taxa'] = taxaList
-
-
-    if result.get('credit'):
-        metaData['credit_line'] = result.get('credit').strip()
-        metaData['pub_date']    = result.get('submitted').strip()
-
-
-    return [
-            foreignID, foreignURL, imgURL,
-            thumbnail if thumbnail else '\\N',
-            str(width) if width else '\\N',
-            str(height) if height else '\\N',
-            license_url,
-            creator if creator else '\\N',
-            title if title else '\\N',
-            json.dumps(metaData, ensure_ascii=False) if bool(metaData) else '\\N',
-            '\\N', 'f', 'phylopic', 'phylopic'
-        ]
-
-
-def commit_to_file_all(**args):
-    startTime = time.time()
-    IDs       = getImageIDs(**args)
+def _commit_to_file_all(**args):
+    start_time = time.time()
+    IDs = _get_image_IDs(**args)
 
     if IDs:
         for id in IDs:
             if id is not None:
-                details = getMetaData(id)
+                details = _get_meta_data(id)
 
                 if details is not None:
                     image_store.add_item(foreign_landing_url=details[1],
@@ -201,19 +96,19 @@ def commit_to_file_all(**args):
                                          creator=details[7],
                                          title=details[8],
                                          meta_data=details[9],
-                    )
+                                         )
         image_store.commit()
         logger.info('Flushed current buffer to file.')
 
-def commit_to_file_date(**args):
-    startTime = time.time()
-    IDs       = getImageIDs(**args)
-    rounds    = len(IDs)//5 if len(IDs)%5 == 0 else len(IDs)//5 + 1
+
+def _commit_to_file_date(**args):
+    start_time = time.time()
+    IDs = _get_image_IDs(**args)
 
     ctr = 1
     while ctr <= len(IDs):
-        if IDs[ctr-1] is not None:
-            details = getMetaData(IDs[ctr-1])
+        if IDs[ctr - 1] is not None:
+            details = _get_meta_data(IDs[ctr - 1])
 
             if details is not None:
                 image_store.add_item(foreign_landing_url=details[1],
@@ -225,7 +120,7 @@ def commit_to_file_date(**args):
                                      creator=details[7],
                                      title=details[8],
                                      meta_data=details[9],
-                )
+                                     )
 
         if ctr % LIMIT == 0:
             # Add 5 images at a time to file
@@ -236,45 +131,190 @@ def commit_to_file_date(**args):
     image_store.commit()
 
 
-def main():
-    logger.info('Begin: PhyloPic API requests')
-    param   = None
-    offset  = 0
+def _get_total_images():
+    # Get the total number of PhyloPic images
+    total = 0
+    endpoint = 'http://phylopic.org/api/a/image/count'
+    request = delayed_requester.get(endpoint, timeout=60)
+    result = request.json()
+
+    if result and result.get('success') is True:
+        total = result.get('result')
+
+    return total
 
 
-    parser  = argparse.ArgumentParser(description='PhyloPic API Job', add_help=True)
-    parser.add_argument('--mode', choices=['default', 'all'],
-            help='Identify all images from the previous day [default]'
-                 ' or process the entire collection [all].')
-    parser.add_argument('--date', default=False, help='Identify all images from'
-        ' a particular date (YYYY-MM-DD).')
-    args = parser.parse_args()
+def _get_image_IDs(**args):
+    limit = LIMIT
+    offset = 0
+    endpoint = ''
 
-    if str(args.mode) == 'all':
-        logger.info('Processing all images')
-        param = {'offset': offset}
-
-        imgCtr  = getTotalImages()
-        logger.info('Total images: {}'.format(imgCtr))
-
-        while offset <= imgCtr:
-            commit_to_file_all(**param)
-            offset += LIMIT
-            param   = {'offset': offset}
-
-    elif args.date is not False:
-        param = {'date': args.date}
-        logger.info('Processing date: {}'.format(param['date']))
-        commit_to_file_date(**param)
+    if args.get('date'):
+        # Get a list of recently updated/uploaded objects.
+        date = args['date']
+        endpoint = 'http://phylopic.org/api/a/image/list/modified/{}'.format(
+                  date)
 
     else:
-        param = {'date': datetime.strftime(datetime.now() - timedelta(1), '%Y-%m-%d')}
-        logger.info('Processing date: {}'.format(param['date']))
-        commit_to_file_date(**param)
+        # Get all images and limit the results for each request.
+        offset = args['offset']
+        endpoint = 'http://phylopic.org/api/a/image/list/{}/{}'.format(
+                  offset, limit)
+
+    if endpoint == '':
+        logger.warning('Unable to parse endpoint: {}, args: {}'.format(
+                       endpoint, args))
+        return [None]
+
+    response = delayed_requester.get(endpoint, timeout=60)
+    result = response.json()
+    image_IDs = []
+
+    if result and result.get('success') is True:
+        data = list(result.get('result'))
+
+        if len(data) > 0:
+            for i in range(len(data)):
+                image_IDs.append(data[i].get('uid'))
+
+    if not image_IDs:
+        logger.warning('No content available!')
+        return [None]
+
+    return image_IDs
 
 
-    logger.info('Terminated!')
+def _get_meta_data(_uuid):
+    logger.info('Processing UUID: {}'.format(_uuid))
+
+    start_time = time.time()
+    base_URL = 'http://phylopic.org'
+    img_URL = ''
+    thumbnail = ''
+    width = ''
+    height = ''
+    foreign_id = ''
+    foreign_url = ''
+    meta_data = {}
+    creator = ''
+    title = ''
+
+    endpoint = "http://phylopic.org/api/a/image/{}?options=credit+" \
+               "licenseURL+pngFiles+submitted+submitter+taxa+canonicalName" \
+               "+string+firstName+lastName".format(_uuid)
+    get_request = delayed_requester.get(endpoint, timeout=60)
+    request = get_request.json()
+
+    if request and request.get('success') is True:
+        result = request['result']
+
+    license_url = result.get('licenseURL')
+    img_info = _get_image_info(result)
+
+    if img_info is not None:
+        img_URL = img_info[0]
+        width = img_info[1]
+        height = img_info[2]
+        thumbnail = img_info[3]
+
+    else:
+        logger.warning('Image not detected in url: {}/image/{}'.format(
+                       base_URL, _uuid))
+        return None
+
+    foreign_id = img_URL
+    foreign_url = '{}/image/{}'.format(base_URL, _uuid)
+
+    first_name = result.get('submitter', {}).get('firstName')
+    last_name = result.get('submitter', {}).get('lastName')
+    creator = '{} {}'.format(first_name, last_name).strip()
+
+    taxa = result.get('taxa', [])
+    # [0].get('canonicalName', {}).get('string')
+    taxa_list = None
+    if taxa:
+        taxa = list(filter(
+            lambda x: x.get('canonicalName') is not None, taxa))
+        taxa_list = list(
+            map(lambda x: x.get('canonicalName', {}).get('string', ''), taxa))
+
+    if taxa_list:
+        title = taxa_list[0]
+
+        if len(taxa_list) > 1:
+            meta_data['taxa'] = taxa_list
+
+    if result.get('credit'):
+        meta_data['credit_line'] = result.get('credit').strip()
+        meta_data['pub_date'] = result.get('submitted').strip()
+
+    return [
+            foreign_id, foreign_url, img_URL,
+            thumbnail if thumbnail else '\\N',
+            str(width) if width else '\\N',
+            str(height) if height else '\\N',
+            license_url,
+            creator if creator else '\\N',
+            title if title else '\\N',
+            json.dumps(
+                meta_data, ensure_ascii=False) if bool(meta_data) else '\\N',
+            '\\N', 'f', 'phylopic', 'phylopic'
+        ]
+
+
+def _get_image_info(result):
+    base_URL = 'http://phylopic.org'
+    img_URL = ''
+    thumbnail = ''
+    width = ''
+    height = ''
+
+    image_info = result.get('pngFiles')
+    if image_info:
+        img = list(filter(lambda x: (
+            int(str(x.get('width', '0'))) >= 257), image_info))
+        img = sorted(img, key=lambda x: x['width'], reverse=True)
+        thb = list(filter(lambda x: str(
+            x.get('width', '')) == '256', image_info))
+
+        if img:
+            img_URL = img[0].get('url')
+            img_URL = '{}{}'.format(base_URL, img_URL)
+            width = img[0].get('width')
+            height = img[0].get('height')
+
+            if thb:
+                thumbnail_info = thb[0].get('url')
+                if thumbnail_info:
+                    thumbnail = '{}{}'.format(base_URL, thumbnail_info)
+
+    if not img_URL:
+        return None
+    else:
+        return [img_URL, width, height, thumbnail]
 
 
 if __name__ == '__main__':
-    main()
+    date = ''
+
+    parser = argparse.ArgumentParser(description='PhyloPic API Job',
+                                     add_help=True)
+    parser.add_argument('--mode', choices=['default', 'all'],
+                        help='Identify all images from the previous day'
+                             ' [default]'
+                             ' or process the entire collection [all].')
+    parser.add_argument('--date', default=False, help='Identify all images'
+                        ' from a particular date (YYYY-MM-DD).')
+    args = parser.parse_args()
+
+    if str(args.mode) == 'all':
+        date = 'all'
+
+    elif args.date is not False:
+        date = str(args.date)
+
+    else:
+        date = str(
+            datetime.strftime(datetime.now() - timedelta(1), '%Y-%m-%d'))
+
+    main(date)

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_phylopic.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_phylopic.py
@@ -1,0 +1,205 @@
+import json
+import logging
+import os
+import requests
+from unittest.mock import patch, MagicMock
+import pytest
+
+import phylopic as pp
+
+RESOURCES = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), 'tests/resources/phylopic'
+)
+
+
+logging.basicConfig(
+    format='%(asctime)s - %(name)s - %(levelname)s:  %(message)s',
+    level=logging.DEBUG,
+)
+
+
+def test_get_total_images_giving_zero():
+    with patch.object(pp, '_get_response_json', return_value=None):
+        img_count = pp._get_total_images()
+        assert img_count == 0
+
+
+def test_get_total_images_correct():
+    with open(
+            os.path.join(RESOURCES, 'total_images_example.json')
+    ) as f:
+        r = json.load(f)
+    with patch.object(
+            pp,
+            '_get_response_json',
+            return_value=r
+    ):
+        img_count = pp._get_total_images()
+        assert img_count == 10
+
+
+def test_create_endpoint_for_IDs_by_date():
+    actual_endpoint = pp._create_endpoint_for_IDs(**{'date': '2020-02-10'})
+    expect_endpoint = str('http://phylopic.org/api'
+                          '/a/image/list/modified/2020-02-10')
+    assert actual_endpoint == expect_endpoint
+
+
+def test_create_endpoint_for_IDs_all():
+    actual_endpoint = pp._create_endpoint_for_IDs(**{'offset': 0})
+    expect_endpoint = 'http://phylopic.org/api/a/image/list/0/100'
+    assert actual_endpoint == expect_endpoint
+
+
+def test_get_image_IDs_for_no_content():
+    with patch.object(pp, '_get_response_json', return_value=None):
+        image_ids = pp._get_image_IDs('')
+        expect_image_ids = [None]
+        assert image_ids == expect_image_ids
+
+
+def test_get_img_IDs_correct():
+    with open(os.path.join(RESOURCES, 'image_ids_example.json')) as f:
+        r = json.load(f)
+    with patch.object(pp, '_get_response_json', return_value=r):
+        actual_img_ids = pp._get_image_IDs('')
+        expect_img_ids = ["863694ac-9f36-40f5-9452-1b435337d9cc",
+                          "329ff574-4bec-4f94-9dd6-9acfec2a6275",
+                          "9c98ff56-8044-483e-b9f1-bf368e4f3322"
+                          ]
+        assert actual_img_ids == expect_img_ids
+
+
+def test_get_meta_data_with_no_img_url():
+    with open(
+            os.path.join(RESOURCES, 'no_image_url_example.json')
+    ) as f:
+        r = json.load(f)
+    with patch.object(pp, '_get_response_json', return_value=r):
+        meta_data = pp._get_meta_data('')
+        assert meta_data is None
+
+
+def test_get_meta_data_for_none_response():
+    with patch.object(pp, '_get_response_json', return_value=None):
+        meta_data = pp._get_meta_data('')
+        assert meta_data is None
+
+
+def test_get_meta_data_correct():
+    with open(
+            os.path.join(RESOURCES, 'correct_meta_data_example.json')
+    ) as f:
+        r = json.load(f)
+    with patch.object(pp, '_get_response_json', return_value=r):
+        actual_meta_data = pp._get_meta_data(
+            'e9df48fe-68ea-419e-b9df-441e0b208335')
+        expect_meta_data = [
+            'http://phylopic.org/assets/images/submissions/e9df48fe-68ea-419e-b9df-441e0b208335.1024.png',
+            'http://phylopic.org/image/e9df48fe-68ea-419e-b9df-441e0b208335',
+            'http://phylopic.org/assets/images/submissions/e9df48fe-68ea-419e-b9df-441e0b208335.1024.png',
+            '', '847', '1024', 'http://creativecommons.org/publicdomain/zero/1.0/',
+            'Jonathan Wells', 'Chondrus crispus NODC Taxonomic Code, database (version 8.0) 1996',
+            {'taxa': ['Chondrus crispus NODC Taxonomic Code, database (version 8.0) 1996'],
+                'credit_line': 'Jonathan Wells', 'pub_date': '2020-02-26 11:59:53'}
+        ]
+        assert actual_meta_data == expect_meta_data
+
+
+def test_get_creator_details():
+    with open(
+            os.path.join(RESOURCES, 'correct_meta_data_example.json')
+    ) as f:
+        r = json.load(f)
+    with patch.object(pp, '_get_response_json', return_value=r):
+        result = r['result']
+        actual_creator_details = pp._get_creator_details(result)
+        expect_creator_details = ('Jonathan Wells',
+                                  'Jonathan Wells', '2020-02-26 11:59:53')
+        assert actual_creator_details == expect_creator_details
+
+
+def test_get_taxa_details():
+    with open(
+            os.path.join(RESOURCES, 'correct_meta_data_example.json')
+    ) as f:
+        r = json.load(f)
+    with patch.object(pp, '_get_response_json', return_value=r):
+        result = r['result']
+        actual_taxa = pp._get_taxa_details(result)
+        expect_taxa = (['Chondrus crispus NODC Taxonomic Code, database (version 8.0) 1996'],
+                       'Chondrus crispus NODC Taxonomic Code, database (version 8.0) 1996'
+                       )
+        assert actual_taxa == expect_taxa
+
+
+def test_get_image_info():
+    with open(
+            os.path.join(RESOURCES, 'correct_meta_data_example.json')
+    ) as f:
+        r = json.load(f)
+    with patch.object(pp, '_get_response_json', return_value=r):
+        result = r['result']
+        actual_img_info = pp._get_image_info(
+            result, 'e9df48fe-68ea-419e-b9df-441e0b208335')
+        expect_img_info = ('http://phylopic.org/assets/images/submissions/e9df48fe-68ea-419e-b9df-441e0b208335.1024.png',
+                           847, 1024, '')
+        assert actual_img_info == expect_img_info
+
+
+def test_get_image_info_with_no_img_url():
+    with open(
+            os.path.join(RESOURCES, 'no_image_url_example.json')
+    ) as f:
+        r = json.load(f)
+    with patch.object(pp, '_get_response_json', return_value=r):
+        result = r['result']
+        actual_img_info = list(pp._get_image_info(result,
+                               '7f7431c6-8f78-498b-92e2-ebf8882a8923'))
+        expect_img_info = [None, None, None, None]
+        assert actual_img_info == expect_img_info
+
+
+def test_get_response_json_retries_with_none_response():
+    with patch.object(
+            pp.delayed_requester,
+            'get',
+            return_value=None
+    ) as mock_get:
+        with pytest.raises(Exception):
+            assert pp._get_response_json({}, retries=2)
+
+    assert mock_get.call_count == 3
+
+
+def test_get_response_json_retries_with_non_ok():
+    r = requests.Response()
+    r.status_code = 504
+    with patch.object(
+            pp.delayed_requester,
+            'get',
+            return_value=r
+    ) as mock_get:
+        with pytest.raises(Exception):
+            assert pp._get_response_json({}, retries=2)
+
+    assert mock_get.call_count == 3
+
+
+def test_get_response_json_returns_response_json_when_all_ok():
+    with open(
+            os.path.join(RESOURCES, 'total_images_example.json')
+    ) as f:
+        expect_response_json = json.load(f)
+    r = requests.Response()
+    r.status_code = 200
+    r.json = MagicMock(return_value=expect_response_json)
+    with patch.object(
+            pp.delayed_requester,
+            'get',
+            return_value=r
+    ) as mock_get:
+        actual_response_json = pp._get_response_json({}, retries=2)
+
+    assert mock_get.call_count == 1
+    assert actual_response_json == expect_response_json

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_phylopic.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_phylopic.py
@@ -47,7 +47,7 @@ def test_create_endpoint_for_IDs_by_date():
 
 def test_create_endpoint_for_IDs_all():
     actual_endpoint = pp._create_endpoint_for_IDs(**{'offset': 0})
-    expect_endpoint = 'http://phylopic.org/api/a/image/list/0/100'
+    expect_endpoint = 'http://phylopic.org/api/a/image/list/0/5'
     assert actual_endpoint == expect_endpoint
 
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_phylopic.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_phylopic.py
@@ -160,6 +160,23 @@ def test_get_image_info_with_no_img_url():
         assert actual_img_info == expect_img_info
 
 
+def test_create_args():
+    id_ = 'e6014244-4dd5-4785-bf2e-c67dc4d05ca8'
+    d = ['http://phylopic.org/assets/images/submissions/e6014244-4dd5-4785-bf2e-c67dc4d05ca8.1024.png', 'http://phylopic.org/image/e6014244-4dd5-4785-bf2e-c67dc4d05ca8',
+         'http://phylopic.org/assets/images/submissions/e6014244-4dd5-4785-bf2e-c67dc4d05ca8.1024.png', 'http://phylopic.org/assets/images/submissions/e6014244-4dd5-4785-bf2e-c67dc4d05ca8.256.png', '1024', '1024', 'http://creativecommons.org/publicdomain/zero/1.0/', 'Jonathan Wells', 'Apicomplexa',
+         {'taxa': ['Apicomplexa', 'Plasmodiidae Mesnil 1903', 'Sporozoa', 'Plasmodium Marchiafava & Celli 1885', 'Plasmodium falciparum', 'Plasmodium (Laverania)', 'Haemospororida Danilewsky', 'Aconoidasida Mehlhorn, Peters & Haberkorn 1980'], 'credit_line': 'Jonathan Wells', 'pub_date': '2020-02-26 13:07:08'}
+         ]
+    actual_args = pp._create_args(d, id_)
+    expect_args = {'foreign_landing_url': 'http://phylopic.org/image/e6014244-4dd5-4785-bf2e-c67dc4d05ca8', 'image_url': 'http://phylopic.org/assets/images/submissions/e6014244-4dd5-4785-bf2e-c67dc4d05ca8.1024.png',
+                   'thumbnail_url': 'http://phylopic.org/assets/images/submissions/e6014244-4dd5-4785-bf2e-c67dc4d05ca8.256.png', 'license_url': 'http://creativecommons.org/publicdomain/zero/1.0/',
+                   'width': '1024', 'height': '1024', 'creator': 'Jonathan Wells', 'title': 'Apicomplexa',
+                   'meta_data': {'taxa': ['Apicomplexa', 'Plasmodiidae Mesnil 1903', 'Sporozoa', 'Plasmodium Marchiafava & Celli 1885', 'Plasmodium falciparum', 'Plasmodium (Laverania)', 'Haemospororida Danilewsky', 'Aconoidasida Mehlhorn, Peters & Haberkorn 1980'], 'credit_line': 'Jonathan Wells', 'pub_date': '2020-02-26 13:07:08'},
+                   'foreign_identifier': 'e6014244-4dd5-4785-bf2e-c67dc4d05ca8'
+                   }
+    assert actual_args == expect_args
+    assert len(actual_args) == 10
+
+
 def test_get_response_json_retries_with_none_response():
     with patch.object(
             pp.delayed_requester,

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/phylopic/correct_meta_data_example.json
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/phylopic/correct_meta_data_example.json
@@ -1,0 +1,49 @@
+{
+  "result": {
+    "uid": "e9df48fe-68ea-419e-b9df-441e0b208335",
+    "taxa": [
+      {
+        "canonicalName": {
+          "uid": "0faa584e-5f44-4520-8c5b-d2e8c7d50292",
+          "string": "Chondrus crispus NODC Taxonomic Code, database (version 8.0) 1996"
+        }
+      }
+    ],
+    "submitted": "2020-02-26 11:59:53",
+    "credit": "Jonathan Wells",
+    "pngFiles": [
+      {
+        "url": "/assets/images/submissions/e9df48fe-68ea-419e-b9df-441e0b208335.64.png",
+        "width": 52,
+        "height": 64
+      },
+      {
+        "url": "/assets/images/submissions/e9df48fe-68ea-419e-b9df-441e0b208335.128.png",
+        "width": 105,
+        "height": 128
+      },
+      {
+        "url": "/assets/images/submissions/e9df48fe-68ea-419e-b9df-441e0b208335.256.png",
+        "width": 211,
+        "height": 256
+      },
+      {
+        "url": "/assets/images/submissions/e9df48fe-68ea-419e-b9df-441e0b208335.512.png",
+        "width": 423,
+        "height": 512
+      },
+      {
+        "url": "/assets/images/submissions/e9df48fe-68ea-419e-b9df-441e0b208335.1024.png",
+        "width": 847,
+        "height": 1024
+      }
+    ],
+    "licenseURL": "http://creativecommons.org/publicdomain/zero/1.0/",
+    "submitter": {
+      "lastName": "Wells",
+      "uid": "8d28b7ec-05f0-4624-8459-b73f1404a7d8",
+      "firstName": "Jonathan"
+    }
+  },
+  "success": true
+}

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/phylopic/image_ids_example.json
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/phylopic/image_ids_example.json
@@ -1,0 +1,8 @@
+{
+  "result": [
+    {"uid": "863694ac-9f36-40f5-9452-1b435337d9cc"},
+    {"uid": "329ff574-4bec-4f94-9dd6-9acfec2a6275"},
+    {"uid": "9c98ff56-8044-483e-b9f1-bf368e4f3322"}
+  ],
+  "success": true
+}

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/phylopic/no_image_url_example.json
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/phylopic/no_image_url_example.json
@@ -1,0 +1,51 @@
+{
+  "result": {
+    "uid": "7f7431c6-8f78-498b-92e2-ebf8882a8923",
+    "taxa": [
+      {
+        "canonicalName": {
+          "uid": "add61d86-ae83-4f65-978f-7ecaf51bbfde",
+          "string": "Martes Pinel, 1792"
+        }
+      },
+      {
+        "canonicalName": {
+          "uid": "cf99c5f9-0f06-42ec-bc55-9795f4f0e485",
+          "string": "Martes foina (Erxleben, 1777)"
+        }
+      },
+      {
+        "canonicalName": {
+          "uid": "82b42c9d-91b3-4048-8f73-f54891c93a59",
+          "string": "Guloninae Gray 1825"
+        }
+      }
+    ],
+    "submitted": "2020-01-28 04:31:19",
+    "credit": "Ferran Sayol",
+    "pngFiles": [
+      {
+        "url": "/assets/images/submissions/7f7431c6-8f78-498b-92e2-ebf8882a8923.64.png",
+        "width": 64,
+        "height": 28
+      },
+      {
+        "url": "/assets/images/submissions/7f7431c6-8f78-498b-92e2-ebf8882a8923.128.png",
+        "width": 128,
+        "height": 57
+      },
+      {
+        "url": "/assets/images/submissions/7f7431c6-8f78-498b-92e2-ebf8882a8923.original.png",
+        "width": 160,
+        "height": 72
+      }
+    ],
+    "licenseURL": "http://creativecommons.org/publicdomain/zero/1.0/",
+    "submitter": {
+      "lastName": "Sayol",
+      "uid": "9fc252de-ba65-45a6-9d1f-42c45bdfab88",
+      "firstName": "Ferran"
+    }
+  },
+  "success": true
+}

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/phylopic/total_images_example.json
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/phylopic/total_images_example.json
@@ -1,0 +1,4 @@
+{
+  "result": 10,
+  "success": true
+}


### PR DESCRIPTION
Fixes #253 

## Description
I've added the provider API script for `PhyloPic`, with appropriate tests for the same.
The following tasks have been completed as mentioned in the issue:
- [x] The new script should be at src/cc_catalog_airflow/dags/provider_api_scripts/phylopic.py (note the capitalization change from the old script name).
- [x] The new script should have a test suite at src/cc_catalog_airflow/dags/provider_api_scripts/test_phylopic.py.
- [x] The new script must use the new ImageStore class (Import this from src/cc_catalog_airflow/dags/provider_api_scripts/common/storage/image.py).
- [x] The new script should use the new DelayedRequester class (Import this from src/cc_catalog_airflow/dags/provider_api_scripts/common/requester.py).
- [x] The new script must not use anything from src/cc_catalog_airflow/dags/provider_api_scripts/modules/etlMods.py. (That module is deprecated)
- [x] The new script must take a --date parameter when run as a script, giving the date for which we should collect images. The form should be YYYY-MM-DD (so, the script can be run via python phylopic.py --date 2018-01-01).
- [x] The new script must provide a main function that takes a date parameter of the same form, and does the exact same thing that running the script from the CLI with the date parameter would do.
- [x] The new script should conform to PEP8. Please use pycodestyle (available via pip install pycodestyle) to check for compliance.
- [x] The new script should use smaller, more testable functions than the old version.
- [x] The test suite for the new script may break PEP8 rules regarding long lines where appropriate (e.g., long strings for testing).



## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x]  I added tests for the changes I made (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
