### PR TITLE
[Issue 222] Date information added to metadata  field

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
@@ -12,7 +12,6 @@ RESOURCES = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), 'tests/resources/wikimedia'
 )
 
-
 logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s:  %(message)s',
     level=logging.DEBUG,
@@ -313,7 +312,8 @@ def test_process_image_data_handles_example_dict():
         creator='PtrQs',
         creator_url='https://commons.wikimedia.org/wiki/User:PtrQs',
         title='File:20120925 PlozevetBretagne LoneTree DSC07971 PtrQs.jpg',
-        meta_data={'description': 'SONY DSC', 'global_usage_count': 0, 'last_modified_at_source': '2019-09-01 00:38:47',
+        meta_data={'description': 'SONY DSC', 'global_usage_count': 0,
+                   'last_modified_at_source': '2019-09-01 00:38:47',
                    'date_originally_created': '2012-09-25 16:23:02'}
     )
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
@@ -313,8 +313,8 @@ def test_process_image_data_handles_example_dict():
         creator='PtrQs',
         creator_url='https://commons.wikimedia.org/wiki/User:PtrQs',
         title='File:20120925 PlozevetBretagne LoneTree DSC07971 PtrQs.jpg',
-        meta_data={'description': 'SONY DSC', 'global_usage_count': 0, 'date_uploaded': '2019-09-01 00:38:47',
-                   'date_taken': '2012-09-25 16:23:02'}
+        meta_data={'description': 'SONY DSC', 'global_usage_count': 0, 'last_modified_at_source': '2019-09-01 00:38:47',
+                   'date_originally_created': '2012-09-25 16:23:02'}
     )
 
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
@@ -313,7 +313,8 @@ def test_process_image_data_handles_example_dict():
         creator='PtrQs',
         creator_url='https://commons.wikimedia.org/wiki/User:PtrQs',
         title='File:20120925 PlozevetBretagne LoneTree DSC07971 PtrQs.jpg',
-        meta_data={'description': 'SONY DSC', 'global_usage_count': 0}
+        meta_data={'description': 'SONY DSC', 'global_usage_count': 0, 'date_uploaded': '2019-09-01 00:38:47',
+                   'date_taken': '2012-09-25 16:23:02'}
     )
 
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -290,6 +290,23 @@ def _get_image_info_dict(image_data):
     return image_info
 
 
+def _extract_date_info(image_info):
+    date_taken = (
+        image_info
+        .get('extmetadata', {})
+        .get('DateTimeOriginal', {})
+        .get('value', '')
+    )
+
+    date_uploaded = (
+        image_info
+        .get('extmetadata', {})
+        .get('DateTime', {})
+        .get('value', '')
+    )
+    return (date_taken, date_uploaded)
+
+
 def _extract_creator_info(image_info):
     artist_string = (
         image_info
@@ -323,6 +340,7 @@ def _create_meta_data_dict(image_data):
     meta_data = {}
     global_usage_length = len(image_data.get('globalusage', []))
     image_info = _get_image_info_dict(image_data)
+    date_taken, date_uploaded = _extract_date_info(image_info)
     description = (
         image_info
         .get('extmetadata', {})
@@ -335,6 +353,8 @@ def _create_meta_data_dict(image_data):
         ).strip()
         meta_data['description'] = description_text
     meta_data['global_usage_count'] = global_usage_length
+    meta_data['date_taken'] = date_taken
+    meta_data['date_uploaded'] = date_uploaded
     return meta_data
 
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -340,7 +340,8 @@ def _create_meta_data_dict(image_data):
     meta_data = {}
     global_usage_length = len(image_data.get('globalusage', []))
     image_info = _get_image_info_dict(image_data)
-    date_originally_created, last_modified_at_source = _extract_date_info(image_info)
+    date_originally_created, last_modified_at_source = _extract_date_info(
+        image_info)
     description = (
         image_info
         .get('extmetadata', {})

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -291,20 +291,20 @@ def _get_image_info_dict(image_data):
 
 
 def _extract_date_info(image_info):
-    date_taken = (
+    date_originally_created = (
         image_info
         .get('extmetadata', {})
         .get('DateTimeOriginal', {})
         .get('value', '')
     )
 
-    date_uploaded = (
+    last_modified_at_source = (
         image_info
         .get('extmetadata', {})
         .get('DateTime', {})
         .get('value', '')
     )
-    return (date_taken, date_uploaded)
+    return (date_originally_created, last_modified_at_source)
 
 
 def _extract_creator_info(image_info):
@@ -340,7 +340,7 @@ def _create_meta_data_dict(image_data):
     meta_data = {}
     global_usage_length = len(image_data.get('globalusage', []))
     image_info = _get_image_info_dict(image_data)
-    date_taken, date_uploaded = _extract_date_info(image_info)
+    date_originally_created, last_modified_at_source = _extract_date_info(image_info)
     description = (
         image_info
         .get('extmetadata', {})
@@ -353,8 +353,8 @@ def _create_meta_data_dict(image_data):
         ).strip()
         meta_data['description'] = description_text
     meta_data['global_usage_count'] = global_usage_length
-    meta_data['date_taken'] = date_taken
-    meta_data['date_uploaded'] = date_uploaded
+    meta_data['date_originally_created'] = date_originally_created
+    meta_data['last_modified_at_source'] = last_modified_at_source
     return meta_data
 
 


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #222

## Description
<!-- Add your description below. -->
I have made changes in the code to include the 'date originally created' and 'date last modified at source' in the metadata field. Verified that those values are being stored together with the description in the tsv file generated when the wikimedia_commons.py file is executed. An existing test was modified to check whether these values are being stored as expected in the metadata field (see test_process_image_data_handles_example_dict function in test_wikimedia_commons.py)


## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x]  I added tests for the changes I made (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
