### PR TITLE
Updated Docstring

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/common/requester.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/common/requester.py
@@ -24,7 +24,7 @@ class DelayedRequester:
 
     def get(self, url, params=None, **kwargs):
         """
-        Make a get request, and return the response json if it exists.
+        Make a get request, and return the response object if it exists.
 
         Required Arguments:
 


### PR DESCRIPTION
Fixes #275 

## Description
Updated the docstring of the `get()` method.


## Checklist
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `master` branch of the repository.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
