### PR TITLE
Fix etlMods.py DeprecationWarning for invalid escape sequence

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/modules/etlMods.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/modules/etlMods.py
@@ -177,7 +177,7 @@ def getLicense(_domain, _path, _url):
         logging.warning('The license for the following work -> {} is not issued by Creative Commons.'.format(_url))
         return [None, None]
 
-    pattern   = re.compile('/(licenses|publicdomain)/([a-z\-?]+)/(\d\.\d)/?(.*?)')
+    pattern   = re.compile(r'/(licenses|publicdomain)/([a-z\-?]+)/(\d\.\d)/?(.*?)')
     if pattern.match(_path.lower()):
         result  = re.search(pattern, _path.lower())
         license = result.group(2).lower().strip()


### PR DESCRIPTION
## Description
When running `pytest` with the given instructions in the README, this is one of the warnings:
```
dags/provider_api_scripts/modules/etlMods.py:180
  /usr/local/airflow/dags/provider_api_scripts/modules/etlMods.py:180: DeprecationWarning: invalid escape sequence \-
    pattern   = re.compile('/(licenses|publicdomain)/([a-z\-?]+)/(\d\.\d)/?(.*?)')
```
This PR fixes this by using Python raw strings, removing this warning entirely.

## Other information
<!-- Add any other information below or delete the "Other Information" line entirely. -->

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
