### PR TITLE
modify issue templates as per comments by Timid Robot and Kriti

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,8 @@
 ---
 name: Bug Report
 about: Create a report to help us improve
-labels: bug
+labels: bug, not ready for work
+title: "[Bug] Replace with Title"
 ---
 
 ## Bug Description

--- a/.github/ISSUE_TEMPLATE/code-quality.md
+++ b/.github/ISSUE_TEMPLATE/code-quality.md
@@ -1,6 +1,7 @@
 ---
 name: Code Quality Improvement Suggestion
 about: Suggest a change that does not add a feature
+labels: not ready for work
 title: "[Quality] Replace with Title"
 ---
 

--- a/.github/ISSUE_TEMPLATE/general-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/general-feature-request.md
@@ -1,8 +1,8 @@
 ---
 name: General Feature Request
 about: Suggest an idea for this project
-title: "[General] Replace with Title"
-labels: enhancement
+title: "[Feature] Replace with Title"
+labels: enhancement, not ready for work
 ---
 
 ## Problem Description

--- a/.github/ISSUE_TEMPLATE/infrastructure-improvement.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure-improvement.md
@@ -1,7 +1,7 @@
 ---
 name: Infrastructure Improvement Suggestion
 about: Suggest a way to improve our infrastructure
-labels: enhancement
+labels: enhancement, not ready for work
 title: "[Infrastructure] Replace with Title"
 ---
 


### PR DESCRIPTION
## Description
<!-- Add your description below. -->
This PR addresses a couple of notes from the retroactive review on #292 from @TimidRobot and @kgodey .  It also adds 'not ready for work' labels to all new issues by default, in accordance with the new contributor guidelines.

## Checklist
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [ ] ~I added tests for the changes I made (if applicable).~
- [ ] ~I added or updated documentation (if applicable).~
- [ ] ~I tried running the project locally and verified that there are no
  visible errors.~

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
