### PR TITLE
method filter moved to query parameter.

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/flickr.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/flickr.py
@@ -33,7 +33,7 @@ MAX_TAG_STRING_LENGTH = 2000
 MAX_DESCRIPTION_LENGTH = 2000
 PROVIDER = 'flickr'
 API_KEY = os.getenv('FLICKR_API_KEY')
-ENDPOINT = 'https://api.flickr.com/services/rest/?method=flickr.photos.search'
+ENDPOINT = 'https://api.flickr.com/services/rest/'
 PHOTO_URL_BASE = 'https://www.flickr.com/photos/'
 DATE_TYPES = ['taken', 'upload']
 
@@ -49,6 +49,7 @@ LICENSE_INFO = {
 }
 
 DEFAULT_QUERY_PARAMS = {
+    'method': 'flickr.photos.search',
     'media': 'photos',
     'content_type': 1,
     'extras': (

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_flickr.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_flickr.py
@@ -117,6 +117,7 @@ def test_build_query_param_dict_default():
         api_key=flickr_api_key
     )
     expect_query_param_dict = {
+        'method': 'flickr.photos.search',
         'media': 'photos',
         'content_type': 1,
         'extras': 'description,license,date_upload,date_taken,owner_name,tags,o_dims,url_t,url_s,url_m,url_l,views',
@@ -148,12 +149,14 @@ def test_build_query_param_dict_with_givens():
         },
         limit=10,
         default_query_param={
+            'method': 'flickr.photos.search',
             'media': 'photos',
             'extras': 'url_t,url_s,url_m,url_l,views',
             'nojsoncallback': 1,
         }
     )
     expect_query_param_dict = {
+        'method': 'flickr.photos.search',
         'media': 'photos',
         'extras': 'url_t,url_s,url_m,url_l,views',
         'nojsoncallback': 1,


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #336 

## Description
method arguement moved to default query parameter dictionary.

## Other information
<!-- Add any other information below or delete the "Other Information" line entirely. -->
Made necessary changes in the tests
## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
