### PR TITLE
Automate linting on Pull Requests and push

### DIFF
--- a/.github/workflows/pull_request_lint.yml
+++ b/.github/workflows/pull_request_lint.yml
@@ -6,8 +6,6 @@ on:
     paths:
       # Changes in python files
       - '*.py'
-    branches:
-      - master
   pull_request:
     # Only run if,
     paths:

--- a/.github/workflows/push_pull_request_lint.yml
+++ b/.github/workflows/push_pull_request_lint.yml
@@ -1,0 +1,35 @@
+name: flake8_lint
+
+on:
+  push:
+    # Only run if,
+    paths:
+      # Changes in python files
+      - '*.py'
+    branches:
+      - master
+  pull_request:
+    # Only run if,
+    paths:
+      # Changes in python files
+      - '*.py'
+    branches:
+      - master
+      
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Setup flake8 annotations  # To annotate the errors in the pull request
+      uses: rbialon/flake8-annotations@v1
+    - name: Lint with flake8
+      # Lint for only changed files, rather than the entire repository
+      run: |
+        pip install flake8
+        git diff HEAD^ | flake8 --diff


### PR DESCRIPTION
Fixes #294  by @mathemancer 

## Description
The workflow will run on any new pull request or push as a separate test and report PEP-8 violations.

Features:
- Runs flake8 on only the changed files, rather than the entire repository.
- Annotates and displays the errors in the Pull request's `Files changed` section itself, making it easy for the contributor to spot and resolve the errors.
- The PR will be automatically rejected and show the failed tests, if there are flake8 errors (PEP-8 violations).

## Technical details
I preferred to use flake8 instead of black because:
- I couldn't find an annotator for black, which I think is an important requirement (to report the fails in the GH UI itself). 
- black is still in its beta version, so it might not be stable as of now.

Moreover, flake8 checks for the same violations as black.

## Tests
Make a test PR with some PEP-8 violations in the changed files.

## Screenshots
![Screenshot from 2020-04-09 00-29-15](https://user-images.githubusercontent.com/20405311/78822666-1ab35780-79f9-11ea-82c4-9e76649c3b77.png)
![Screenshot from 2020-04-09 00-29-34](https://user-images.githubusercontent.com/20405311/78822703-27d04680-79f9-11ea-8a04-31fd48a9ceb4.png)



## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] ~I added tests for the changes I made (if applicable).~
- [ ] ~I added or updated documentation (if applicable).~
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
