### PR TITLE
Split dependencies into prod and dev

### DIFF
--- a/src/cc_catalog_airflow/Dockerfile
+++ b/src/cc_catalog_airflow/Dockerfile
@@ -12,11 +12,11 @@ USER airflow
 
 RUN mkdir -p ${OUTPUT_DIR}
 WORKDIR  ${AIRFLOW_HOME}
-ADD ./requirements.txt ${AIRFLOW_HOME}
+ADD ./requirements_dev.txt ${AIRFLOW_HOME}
 ADD ./wait_for_db.py ${AIRFLOW_HOME}
 ADD ./dags ${AIRFLOW_HOME}/dags
 
-RUN pip install --user -r requirements.txt
+RUN pip install --user -r requirements_dev.txt
 
 CMD python wait_for_db.py && \
   airflow initdb && \

--- a/src/cc_catalog_airflow/requirements_dev.txt
+++ b/src/cc_catalog_airflow/requirements_dev.txt
@@ -1,0 +1,10 @@
+apache-airflow[aws,crypto,postgres]==1.10.9
+lxml
+python-dateutil
+requests
+SQLAlchemy==1.3.15
+
+ipython
+pytest
+pytest-cov
+pytest-socket

--- a/src/cc_catalog_airflow/requirements_prod.txt
+++ b/src/cc_catalog_airflow/requirements_prod.txt
@@ -3,8 +3,3 @@ lxml==4.4.2
 python-dateutil==2.8.0
 requests==2.22.0
 SQLAlchemy==1.3.15
-
-ipython
-pytest
-pytest-cov
-pytest-socket


### PR DESCRIPTION
This is for the issue https://github.com/creativecommons/cccatalog/issues/362. Created different files for dev and prod in src/cc_catalog_airflow. The files are requirements_dev.txt and requirements_prod.txt.