### PR TITLE
Changed requirements.txt to requirements_dev.txt

### DIFF
--- a/src/cc_catalog_airflow/Dockerfile
+++ b/src/cc_catalog_airflow/Dockerfile
@@ -16,7 +16,7 @@ ADD ./requirements.txt ${AIRFLOW_HOME}
 ADD ./wait_for_db.py ${AIRFLOW_HOME}
 ADD ./dags ${AIRFLOW_HOME}/dags
 
-RUN pip install --user -r requirements.txt
+RUN pip install --user -r requirements_dev.txt
 
 CMD python wait_for_db.py && \
   airflow initdb && \


### PR DESCRIPTION
The PR related to #362 was failing because in dockerfile requirements.txt was being used but there wasn't such file in src/cc_catalog_airflow so I changed the requirements.txt to requirements_dev.txt.

