### PR TITLE
Load results of Provider API Script runs to S3, as well as PostgreSQL

### DIFF
--- a/src/cc_catalog_airflow/dags/loader_workflow.py
+++ b/src/cc_catalog_airflow/dags/loader_workflow.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 DAG_ID = 'tsv_to_postgres_loader'
 DB_CONN_ID = os.getenv('OPENLEDGER_CONN_ID', 'postgres_openledger_testing')
+AWS_CONN_ID = os.getenv('AWS_CONN_ID', 'no_aws_conn_id')
 MINIMUM_FILE_AGE_MINUTES = 1
 CONCURRENCY = 5
 SCHEDULE_CRON = '* * * * *'
@@ -39,6 +40,7 @@ def create_dag(
         max_active_runs=CONCURRENCY,
         schedule_cron=SCHEDULE_CRON,
         postgres_conn_id=DB_CONN_ID,
+        aws_conn_id=AWS_CONN_ID,
         output_dir=OUTPUT_DIR_PATH,
         minimum_file_age_minutes=MINIMUM_FILE_AGE_MINUTES
 ):
@@ -57,6 +59,13 @@ def create_dag(
             output_dir,
             minimum_file_age_minutes
         )
+
+        load_data_to_s3 = operators.get_s3_loader_operator(
+            dag,
+            output_dir,
+            aws_conn_id
+        )
+
         create_loading_table = operators.get_table_creator_operator(
             dag,
             postgres_conn_id
@@ -78,9 +87,9 @@ def create_dag(
             dag,
             output_dir
         )
+        stage_oldest_tsv_file >> [create_loading_table, load_data_to_s3]
         (
-            stage_oldest_tsv_file
-            >> create_loading_table
+            create_loading_table
             >> load_data
             >> [delete_staged_file, drop_loading_table]
         )

--- a/src/cc_catalog_airflow/dags/loader_workflow.py
+++ b/src/cc_catalog_airflow/dags/loader_workflow.py
@@ -88,11 +88,8 @@ def create_dag(
             output_dir
         )
         stage_oldest_tsv_file >> [create_loading_table, load_data_to_s3]
-        (
-            create_loading_table
-            >> load_data
-            >> [delete_staged_file, drop_loading_table]
-        )
+        [create_loading_table, load_data_to_s3] >> load_data
+        load_data >> [delete_staged_file, drop_loading_table]
         [
             stage_oldest_tsv_file,
             create_loading_table,

--- a/src/cc_catalog_airflow/dags/util/loader/loader.py
+++ b/src/cc_catalog_airflow/dags/util/loader/loader.py
@@ -1,4 +1,4 @@
-from util.loader import paths, sql
+from util.loader import paths, s3, sql
 
 
 def load_data(output_dir, postgres_conn_id, identifier):
@@ -9,3 +9,8 @@ def load_data(output_dir, postgres_conn_id, identifier):
         identifier
     )
     sql.upsert_records_to_image_table(postgres_conn_id, identifier)
+
+
+def load_data_to_s3(output_dir, identifier, aws_conn_id):
+    tsv_file_name = paths.get_staged_file(output_dir, identifier)
+    s3.copy_file_to_s3_staging(identifier, tsv_file_name, aws_conn_id)

--- a/src/cc_catalog_airflow/dags/util/loader/operators.py
+++ b/src/cc_catalog_airflow/dags/util/loader/operators.py
@@ -48,6 +48,7 @@ def get_loader_operator(
         task_id='load_data',
         python_callable=loader.load_data,
         op_args=[output_dir, postgres_conn_id, identifier],
+        trigger_rule=TriggerRule.ALL_DONE,
         dag=dag
     )
 

--- a/src/cc_catalog_airflow/dags/util/loader/operators.py
+++ b/src/cc_catalog_airflow/dags/util/loader/operators.py
@@ -52,6 +52,20 @@ def get_loader_operator(
     )
 
 
+def get_s3_loader_operator(
+        dag,
+        output_dir,
+        aws_conn_id,
+        identifier=TIMESTAMP_TEMPLATE
+):
+    return PythonOperator(
+        task_id='load_data_to_s3',
+        python_callable=loader.load_data_to_s3,
+        op_args=[output_dir, identifier, aws_conn_id],
+        dag=dag
+    )
+
+
 def get_file_deletion_operator(
         dag,
         output_dir,

--- a/src/cc_catalog_airflow/dags/util/loader/s3.py
+++ b/src/cc_catalog_airflow/dags/util/loader/s3.py
@@ -3,8 +3,6 @@ import os
 
 from airflow.hooks.S3_hook import S3Hook
 
-import boto3
-
 logger = logging.getLogger(__name__)
 
 DEFAULT_MEDIA_PREFIX = 'image'
@@ -23,42 +21,19 @@ def copy_file_to_s3_staging(
     logger.info(f'Creating staging object in s3_bucket:  {s3_bucket}')
     s3 = S3Hook(aws_conn_id=aws_conn_id)
     file_name = os.path.split(tsv_file_path)[1]
-    staging_prefix = _get_staging_prefix(identifier)
-    staging_key = _s3_join_path(staging_prefix, file_name)
+    staging_object_prefix = _get_staging_object_prefix(
+        identifier,
+        media_prefix,
+        staging_prefix
+    )
+    staging_key = _s3_join_path(staging_object_prefix, file_name)
     s3.load_file(tsv_file_path, staging_key, bucket_name=s3_bucket)
 
 
-def create_staging_object(
+def _get_staging_object_prefix(
         identifier,
-        tsv_file_name,
-        staging_prefix=STAGING_PREFIX,
-        s3_bucket=None,
-        access_key=None,
-        secret_key=None,
-):
-    s3_bucket = s3_bucket or os.getenv('CCCATALOG_STORAGE_BUCKET')
-    access_key = access_key or os.getenv('AWS_ACCESS_KEY')
-    secret_key = secret_key or os.getenv('AWS_SECRET_KEY')
-    logger.info(f'Creating staging object in s3_bucket:  {s3_bucket}')
-    file_name = os.path.split(tsv_file_name)[1]
-    s3_object_key = _s3_join_path(staging_prefix, identifier, file_name)
-    logger.info(f's3_object_key:  {s3_object_key}')
-    s3_object = (
-        boto3
-        .resource(
-            's3',
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key
-        )
-        .Object(s3_bucket, s3_object_key)
-    )
-    return s3_object
-
-
-def _get_staging_prefix(
-        identifier,
-        media_prefix=DEFAULT_MEDIA_PREFIX,
-        staging_prefix=STAGING_PREFIX,
+        media_prefix,
+        staging_prefix,
 ):
     return _s3_join_path(media_prefix, staging_prefix, identifier)
 

--- a/src/cc_catalog_airflow/dags/util/loader/s3.py
+++ b/src/cc_catalog_airflow/dags/util/loader/s3.py
@@ -1,0 +1,69 @@
+import logging
+import os
+
+from airflow.hooks.S3_hook import S3Hook
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MEDIA_PREFIX = 'image'
+STAGING_PREFIX = 'db_loader_staging'
+
+
+def copy_file_to_s3_staging(
+        identifier,
+        tsv_file_path,
+        aws_conn_id,
+        media_prefix=DEFAULT_MEDIA_PREFIX,
+        staging_prefix=STAGING_PREFIX,
+        s3_bucket=None
+):
+    s3_bucket = s3_bucket or os.getenv('CCCATALOG_STORAGE_BUCKET')
+    logger.info(f'Creating staging object in s3_bucket:  {s3_bucket}')
+    s3 = S3Hook(aws_conn_id=aws_conn_id)
+    file_name = os.path.split(tsv_file_path)[1]
+    staging_prefix = _get_staging_prefix(identifier)
+    staging_key = _s3_join_path(staging_prefix, file_name)
+    s3.load_file(tsv_file_path, staging_key, bucket_name=s3_bucket)
+
+
+def create_staging_object(
+        identifier,
+        tsv_file_name,
+        staging_prefix=STAGING_PREFIX,
+        s3_bucket=None,
+        access_key=None,
+        secret_key=None,
+):
+    s3_bucket = s3_bucket or os.getenv('CCCATALOG_STORAGE_BUCKET')
+    access_key = access_key or os.getenv('AWS_ACCESS_KEY')
+    secret_key = secret_key or os.getenv('AWS_SECRET_KEY')
+    logger.info(f'Creating staging object in s3_bucket:  {s3_bucket}')
+    file_name = os.path.split(tsv_file_name)[1]
+    s3_object_key = _s3_join_path(staging_prefix, identifier, file_name)
+    logger.info(f's3_object_key:  {s3_object_key}')
+    s3_object = (
+        boto3
+        .resource(
+            's3',
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key
+        )
+        .Object(s3_bucket, s3_object_key)
+    )
+    return s3_object
+
+
+def _get_staging_prefix(
+        identifier,
+        media_prefix=DEFAULT_MEDIA_PREFIX,
+        staging_prefix=STAGING_PREFIX,
+):
+    return _s3_join_path(media_prefix, staging_prefix, identifier)
+
+
+def _s3_join_path(*args):
+    return '/'.join(
+        [s.strip('/') for s in args]
+    )

--- a/src/cc_catalog_airflow/dags/util/loader/test_s3.py
+++ b/src/cc_catalog_airflow/dags/util/loader/test_s3.py
@@ -1,0 +1,87 @@
+import os
+from unittest.mock import patch
+
+import boto3
+
+from util.loader import s3
+
+TEST_ID = 'testing'
+TEST_MEDIA_PREFIX = 'media'
+TEST_STAGING_PREFIX = 'test_staging'
+AWS_CONN_ID = os.getenv('AWS_TEST_CONN_ID')
+
+
+def test_copy_file_to_s3_staging_uses_connection_id():
+    identifier = TEST_ID
+    media_prefix = TEST_MEDIA_PREFIX
+    staging_prefix = TEST_STAGING_PREFIX
+    tsv_file_path = '/test/file/path/to/data.tsv'
+    aws_conn_id = 'test_conn_id'
+
+    with patch.object(s3, 'S3Hook') as mock_s3:
+        s3.copy_file_to_s3_staging(
+            identifier,
+            tsv_file_path,
+            aws_conn_id,
+            media_prefix=media_prefix,
+            staging_prefix=staging_prefix
+        )
+    mock_s3.assert_called_once_with(aws_conn_id=aws_conn_id)
+
+
+def test_copy_file_to_s3_staging_uses_bucket_environ(monkeypatch):
+    identifier = TEST_ID
+    media_prefix = TEST_MEDIA_PREFIX
+    staging_prefix = TEST_STAGING_PREFIX
+    tsv_file_path = '/test/file/path/to/data.tsv'
+    aws_conn_id = 'test_conn_id'
+    test_bucket_name = 'test-bucket'
+    monkeypatch.setenv('CCCATALOG_STORAGE_BUCKET', test_bucket_name)
+
+    with patch.object(
+            s3.S3Hook,
+            'load_file'
+    ) as mock_s3_load_file:
+        s3.copy_file_to_s3_staging(
+            identifier,
+            tsv_file_path,
+            aws_conn_id,
+            media_prefix=media_prefix,
+            staging_prefix=staging_prefix
+        )
+    mock_s3_load_file.assert_called_once_with(
+        tsv_file_path,
+        f'{media_prefix}/{staging_prefix}/{identifier}/data.tsv',
+        bucket_name=test_bucket_name
+    )
+
+
+def test_copy_file_to_s3_staging_given_bucket_name(monkeypatch):
+    identifier = TEST_ID
+    media_prefix = TEST_MEDIA_PREFIX
+    staging_prefix = TEST_STAGING_PREFIX
+    tsv_file_path = '/test/file/path/to/data.tsv'
+    aws_conn_id = 'test_conn_id'
+    test_bucket_env = 'test-bucket'
+    monkeypatch.setenv('CCCATALOG_STORAGE_BUCKET', test_bucket_env)
+    test_bucket_name = 'test-bucket-given'
+
+    with patch.object(
+            s3.S3Hook,
+            'load_file'
+    ) as mock_s3_load_file:
+        s3.copy_file_to_s3_staging(
+            identifier,
+            tsv_file_path,
+            aws_conn_id,
+            media_prefix=media_prefix,
+            staging_prefix=staging_prefix,
+            s3_bucket=test_bucket_name
+        )
+    print(mock_s3_load_file.mock_calls)
+    print(mock_s3_load_file.method_calls)
+    mock_s3_load_file.assert_called_once_with(
+        tsv_file_path,
+        f'{media_prefix}/{staging_prefix}/{identifier}/data.tsv',
+        bucket_name=test_bucket_name
+    )

--- a/src/cc_catalog_airflow/docker-compose.yml
+++ b/src/cc_catalog_airflow/docker-compose.yml
@@ -12,6 +12,12 @@ services:
     volumes:
       - /tmp/docker_postgres_data:/var/lib/postgresql/data
 
+  s3:
+    build:
+      context: ./local_s3
+    ports:
+      - "5000:5000"
+
   webserver:
     build:
       context: .
@@ -21,5 +27,6 @@ services:
     restart: always
     depends_on:
       - postgres
+      - s3
     ports:
       - "${AIRFLOW_PORT}:8080"

--- a/src/cc_catalog_airflow/env.template
+++ b/src/cc_catalog_airflow/env.template
@@ -1,8 +1,9 @@
 # Change OUTPUT_DIR as appropriate for production
 OUTPUT_DIR=/tmp/
 
-THINGIVERSE_TOKEN=not_set
+BROOKLYN_MUSEUM_API_KEY=not_set
 FLICKR_API_KEY=not_set
+THINGIVERSE_TOKEN=not_set
 WM_SCRIPT_CONTACT=cc.catalog@creativecommons.org
 
 S3_BUCKET=not_set
@@ -24,5 +25,13 @@ AIRFLOW_CONN_POSTGRES_OPENLEDGER_TESTING=postgres://deploy:deploy@postgres:5432/
 
 OPENLEDGER_CONN_ID=postgres_openledger_upstream
 TEST_CONN_ID=postgres_openledger_testing
+
+AIRFLOW_CONN_AWS_PROD=aws://test_key:test_secret@?region_name=us-east-1&host=http://s3:5000
+AIRFLOW_CONN_AWS_TEST=aws://test_key:test_secret@?region_name=us-east-1&host=http://s3:5000
+
+AWS_CONN_ID=aws_prod
+AWS_TEST_CONN_ID=aws_test
+
+CCCATALOG_STORAGE_BUCKET=cccatalog-storage
 
 AIRFLOW_PORT=9090

--- a/src/cc_catalog_airflow/local_s3/Dockerfile
+++ b/src/cc_catalog_airflow/local_s3/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.7-buster
+
+
+ARG CCCATALOG_STORAGE_BUCKET
+ENV SCRIPT_DIR=/app
+
+WORKDIR ${SCRIPT_DIR}
+ADD ./create_bucket.py ${SCRIPT_DIR}
+RUN pip install moto[server]
+
+CMD python create_bucket.py & moto_server s3 -H 0.0.0.0

--- a/src/cc_catalog_airflow/local_s3/create_bucket.py
+++ b/src/cc_catalog_airflow/local_s3/create_bucket.py
@@ -38,7 +38,7 @@ def _create_local_s3_bucket(tries=TRIES, s3=S3, bucket_name=BUCKET_NAME):
         try:
             logger.info(
                 f'Attempting to create bucket {bucket_name}'
-                f' using local s3 connection'
+                ' using local s3 connection'
             )
             s3.create_bucket(Bucket=bucket_name)
             success = True

--- a/src/cc_catalog_airflow/local_s3/create_bucket.py
+++ b/src/cc_catalog_airflow/local_s3/create_bucket.py
@@ -1,0 +1,47 @@
+import logging
+import time
+
+import boto3
+from botocore.httpsession import EndpointConnectionError
+
+logging.basicConfig(
+    format='%(asctime)s - %(name)s - %(levelname)s:  %(message)s',
+    level=logging.INFO
+)
+
+logger = logging.getLogger(__file__)
+
+TRIES = 10
+S3 = boto3.resource(
+    service_name='s3',
+    region_name='us-east-1',
+    endpoint_url='http://localhost:5000',
+    aws_access_key_id='test_key',
+    aws_secret_access_key='test_secret',
+)
+BUCKET_NAME = 'cccatalog-storage'
+
+
+def create_local_s3_bucket(tries=TRIES, s3=S3, bucket_name=BUCKET_NAME):
+    success = False
+    for i in range(1, TRIES + 1):
+        try:
+            logger.info(
+                f'Attempting to create bucket {bucket_name}'
+                f' using local s3 connection'
+            )
+            s3.create_bucket(Bucket=bucket_name)
+            success = True
+            break
+        except EndpointConnectionError as conn_e:
+            logger.info('S3 not yet available')
+            logger.debug(f'Error was:  {conn_e}')
+            logger.info(f'Waiting {i} seconds...')
+            # Back off with each loop to give the S3 container a chance to
+            # start.
+            time.sleep(i)
+    return success
+
+
+if __name__ == '__main__':
+    create_local_s3_bucket()

--- a/src/cc_catalog_airflow/local_s3/create_bucket.py
+++ b/src/cc_catalog_airflow/local_s3/create_bucket.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import time
 
 import boto3
@@ -22,7 +23,16 @@ S3 = boto3.resource(
 BUCKET_NAME = 'cccatalog-storage'
 
 
-def create_local_s3_bucket(tries=TRIES, s3=S3, bucket_name=BUCKET_NAME):
+def main():
+    success = _create_local_s3_bucket()
+    if not success:
+        logger.error(f'Could not create bucket in local S3')
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+def _create_local_s3_bucket(tries=TRIES, s3=S3, bucket_name=BUCKET_NAME):
     success = False
     for i in range(1, TRIES + 1):
         try:
@@ -44,4 +54,4 @@ def create_local_s3_bucket(tries=TRIES, s3=S3, bucket_name=BUCKET_NAME):
 
 
 if __name__ == '__main__':
-    create_local_s3_bucket()
+    main()

--- a/src/cc_catalog_airflow/requirements.txt
+++ b/src/cc_catalog_airflow/requirements.txt
@@ -3,6 +3,8 @@ lxml==4.4.2
 python-dateutil==2.8.0
 requests==2.22.0
 SQLAlchemy==1.3.15
+WTForms==2.2.1
+docutils==0.15.2
 
 ipython
 pytest

--- a/src/cc_catalog_airflow/wait_for_db.py
+++ b/src/cc_catalog_airflow/wait_for_db.py
@@ -10,7 +10,7 @@ logging.basicConfig(
     level=logging.INFO
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__file__)
 
 TRIES = 10
 CONN_ID = os.getenv('AIRFLOW__CORE__SQL_ALCHEMY_CONN')


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #333 by @mathemancer 

## Description
<!-- Concisely describe what the pull request does. -->
This PR modifies the Apache Airflow DAG (Directed Acyclic Graph) defined at `src/cc_catalog_airflow/dags/loader_workflow.py` so that it now loads the staged TSV (tab separated value) file to an AWS S3 bucket before attempting to load it into the PostgreSQL database.  Note that the DAG will still attempt to load the data into PostgreSQL, even if loading the file to S3 fails.  

Also included is a local S3 mock server that allows running the entire DAG locally without touching actual Amazon AWS at all.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Follow the instructions in the `README.md` to run the tests.  For even more excitement:
1. Login to the `cc_catalog_airflow_webserver_1` container (after following the `README.md` to bring up the environment):
```shell
docker exec -it cc_catalog_airflow_webserver_1 /bin/bash
```
2. Copy an example tsv to the `/tmp/` directory in the container:
```shell
cp /usr/local/airflow/dags/provider_api_scripts/tests/resources/example_output/phylopic_1561673410.tsv /tmp/
```
3. Go to `localhost:9090` in your browser, and toggle the `tsv_to_postgres_loader` DAG to 'On'
4. Click on the tiny 'tree' icon in the interface for that DAG.  Watch the lights turn green.  It may take a couple of runs before anything interesting happens, since the DAG waits for the file to be unmodified for a minute before it does anything.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] ~I added or updated documentation (if applicable).~
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
