### PR TITLE
Load TSV from S3 to postgres, rather than local copy on EC2

### DIFF
--- a/src/cc_catalog_airflow/dags/loader_workflow.py
+++ b/src/cc_catalog_airflow/dags/loader_workflow.py
@@ -68,6 +68,7 @@ def create_dag(
         copy_to_s3 = operators.get_copy_to_s3_operator(
             dag,
             output_dir,
+            storage_bucket,
             aws_conn_id
         )
         load_s3_data = operators.get_load_s3_data_operator(

--- a/src/cc_catalog_airflow/dags/util/loader/loader.py
+++ b/src/cc_catalog_airflow/dags/util/loader/loader.py
@@ -3,7 +3,7 @@ from util.loader import paths, s3, sql
 
 def load_local_data(output_dir, postgres_conn_id, identifier):
     tsv_file_name = paths.get_staged_file(output_dir, identifier)
-    sql.import_data_to_intermediate_table(
+    sql.load_local_data_to_intermediate_table(
         postgres_conn_id,
         tsv_file_name,
         identifier

--- a/src/cc_catalog_airflow/dags/util/loader/loader.py
+++ b/src/cc_catalog_airflow/dags/util/loader/loader.py
@@ -11,9 +11,9 @@ def load_local_data(output_dir, postgres_conn_id, identifier):
     sql.upsert_records_to_image_table(postgres_conn_id, identifier)
 
 
-def copy_to_s3(output_dir, identifier, aws_conn_id):
+def copy_to_s3(output_dir, bucket, identifier, aws_conn_id):
     tsv_file_name = paths.get_staged_file(output_dir, identifier)
-    s3.copy_file_to_s3_staging(identifier, tsv_file_name, aws_conn_id)
+    s3.copy_file_to_s3_staging(identifier, tsv_file_name, bucket, aws_conn_id)
 
 
 def load_s3_data(
@@ -22,4 +22,11 @@ def load_s3_data(
         postgres_conn_id,
         identifier
 ):
-    pass
+    tsv_key = s3.get_staged_s3_object(identifier, bucket, aws_conn_id)
+    sql.load_s3_data_to_intermediate_table(
+        postgres_conn_id,
+        bucket,
+        tsv_key,
+        identifier
+    )
+    sql.upsert_records_to_image_table(postgres_conn_id, identifier)

--- a/src/cc_catalog_airflow/dags/util/loader/loader.py
+++ b/src/cc_catalog_airflow/dags/util/loader/loader.py
@@ -1,7 +1,7 @@
 from util.loader import paths, s3, sql
 
 
-def load_data(output_dir, postgres_conn_id, identifier):
+def load_local_data(output_dir, postgres_conn_id, identifier):
     tsv_file_name = paths.get_staged_file(output_dir, identifier)
     sql.import_data_to_intermediate_table(
         postgres_conn_id,
@@ -11,6 +11,15 @@ def load_data(output_dir, postgres_conn_id, identifier):
     sql.upsert_records_to_image_table(postgres_conn_id, identifier)
 
 
-def load_data_to_s3(output_dir, identifier, aws_conn_id):
+def copy_to_s3(output_dir, identifier, aws_conn_id):
     tsv_file_name = paths.get_staged_file(output_dir, identifier)
     s3.copy_file_to_s3_staging(identifier, tsv_file_name, aws_conn_id)
+
+
+def load_s3_data(
+        bucket,
+        aws_conn_id,
+        postgres_conn_id,
+        identifier
+):
+    pass

--- a/src/cc_catalog_airflow/dags/util/loader/operators.py
+++ b/src/cc_catalog_airflow/dags/util/loader/operators.py
@@ -1,5 +1,6 @@
 import logging
 
+from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.python_operator import ShortCircuitOperator
 from airflow.utils.trigger_rule import TriggerRule
@@ -38,32 +39,91 @@ def get_table_creator_operator(
     )
 
 
-def get_loader_operator(
+def get_load_local_data_operator(
         dag,
         output_dir,
         postgres_conn_id,
         identifier=TIMESTAMP_TEMPLATE
 ):
     return PythonOperator(
-        task_id='load_data',
-        python_callable=loader.load_data,
+        task_id='load_local_data',
+        python_callable=loader.load_local_data,
         op_args=[output_dir, postgres_conn_id, identifier],
-        trigger_rule=TriggerRule.ALL_DONE,
+        trigger_rule=TriggerRule.ALL_SUCCESS,
         dag=dag
     )
 
 
-def get_s3_loader_operator(
+def get_copy_to_s3_operator(
         dag,
         output_dir,
         aws_conn_id,
         identifier=TIMESTAMP_TEMPLATE
 ):
     return PythonOperator(
-        task_id='load_data_to_s3',
-        python_callable=loader.load_data_to_s3,
+        task_id='copy_to_s3',
+        python_callable=loader.copy_to_s3,
         op_args=[output_dir, identifier, aws_conn_id],
         dag=dag
+    )
+
+
+def get_load_s3_data_operator(
+        dag,
+        bucket,
+        aws_conn_id,
+        postgres_conn_id,
+        identifier=TIMESTAMP_TEMPLATE
+):
+    return PythonOperator(
+        task_id='load_s3_data',
+        python_callable=loader.load_s3_data,
+        op_args=[bucket, aws_conn_id, postgres_conn_id, identifier],
+        dag=dag
+    )
+
+
+def get_one_failed_switch(
+        dag,
+        identifer
+):
+    return DummyOperator(
+        task_id=f'one_failed_{identifer}',
+        trigger_rule=TriggerRule.ONE_FAILED,
+        dag=dag,
+    )
+
+
+def get_all_failed_switch(
+        dag,
+        identifer
+):
+    return DummyOperator(
+        task_id=f'all_failed_{identifer}',
+        trigger_rule=TriggerRule.ALL_FAILED,
+        dag=dag,
+    )
+
+
+def get_one_success_switch(
+        dag,
+        identifer
+):
+    return DummyOperator(
+        task_id=f'one_success_{identifer}',
+        trigger_rule=TriggerRule.ONE_SUCCESS,
+        dag=dag,
+    )
+
+
+def get_all_done_switch(
+        dag,
+        identifer
+):
+    return DummyOperator(
+        task_id=f'all_done_{identifer}',
+        trigger_rule=TriggerRule.ALL_DONE,
+        dag=dag,
     )
 
 
@@ -104,6 +164,6 @@ def get_failure_moving_operator(
         task_id='move_staged_failures',
         python_callable=paths.move_staged_files_to_failure_directory,
         op_args=[output_dir, identifier],
-        trigger_rule=TriggerRule.ONE_FAILED,
+        trigger_rule=TriggerRule.ONE_SUCCESS,
         dag=dag
     )

--- a/src/cc_catalog_airflow/dags/util/loader/operators.py
+++ b/src/cc_catalog_airflow/dags/util/loader/operators.py
@@ -57,13 +57,14 @@ def get_load_local_data_operator(
 def get_copy_to_s3_operator(
         dag,
         output_dir,
+        storage_bucket,
         aws_conn_id,
         identifier=TIMESTAMP_TEMPLATE
 ):
     return PythonOperator(
         task_id='copy_to_s3',
         python_callable=loader.copy_to_s3,
-        op_args=[output_dir, identifier, aws_conn_id],
+        op_args=[output_dir, storage_bucket, identifier, aws_conn_id],
         dag=dag
     )
 

--- a/src/cc_catalog_airflow/dags/util/loader/s3.py
+++ b/src/cc_catalog_airflow/dags/util/loader/s3.py
@@ -12,12 +12,11 @@ STAGING_PREFIX = 'db_loader_staging'
 def copy_file_to_s3_staging(
         identifier,
         tsv_file_path,
+        s3_bucket,
         aws_conn_id,
         media_prefix=DEFAULT_MEDIA_PREFIX,
         staging_prefix=STAGING_PREFIX,
-        s3_bucket=None
 ):
-    s3_bucket = s3_bucket or os.getenv('CCCATALOG_STORAGE_BUCKET')
     logger.info(f'Creating staging object in s3_bucket:  {s3_bucket}')
     s3 = S3Hook(aws_conn_id=aws_conn_id)
     file_name = os.path.split(tsv_file_path)[1]
@@ -28,6 +27,24 @@ def copy_file_to_s3_staging(
     )
     staging_key = _s3_join_path(staging_object_prefix, file_name)
     s3.load_file(tsv_file_path, staging_key, bucket_name=s3_bucket)
+
+
+def get_staged_s3_object(
+        identifier,
+        s3_bucket,
+        aws_conn_id,
+        media_prefix=DEFAULT_MEDIA_PREFIX,
+        staging_prefix=STAGING_PREFIX,
+):
+    s3 = S3Hook(aws_conn_id=aws_conn_id)
+    staging_object_prefix = _get_staging_object_prefix(
+        identifier,
+        media_prefix,
+        staging_prefix
+    )
+    key_list = s3.list_keys(s3_bucket, prefix=staging_object_prefix)
+    assert len(key_list) == 1
+    return key_list[0]
 
 
 def _get_staging_object_prefix(

--- a/src/cc_catalog_airflow/dags/util/loader/sql.py
+++ b/src/cc_catalog_airflow/dags/util/loader/sql.py
@@ -69,6 +69,29 @@ def load_local_data_to_intermediate_table(
     _clean_intermediate_table_data(postgres, load_table)
 
 
+def load_s3_data_to_intermediate_table(
+        postgres_conn_id,
+        bucket,
+        s3_key,
+        identifier
+):
+    load_table = _get_load_table_name(identifier)
+    logger.info(f'Loading {s3_key} from S3 Bucket {bucket} into {load_table}')
+
+    postgres = PostgresHook(postgres_conn_id=postgres_conn_id)
+    postgres.run(
+        f"SELECT aws_s3.table_import_from_s3("
+        f"'{load_table}',"
+        f"'',"
+        f"'DELIMITER E''\t''',"
+        f"'{bucket}',"
+        f"'{s3_key}',"
+        f"'us-east-1'"
+        f");"
+    )
+    _clean_intermediate_table_data(postgres, load_table)
+
+
 def _clean_intermediate_table_data(
         postgres_hook,
         load_table

--- a/src/cc_catalog_airflow/dags/util/loader/sql.py
+++ b/src/cc_catalog_airflow/dags/util/loader/sql.py
@@ -56,7 +56,7 @@ def create_loading_table(
     )
 
 
-def import_data_to_intermediate_table(
+def load_local_data_to_intermediate_table(
         postgres_conn_id,
         tsv_file_name,
         identifier
@@ -66,19 +66,26 @@ def import_data_to_intermediate_table(
 
     postgres = PostgresHook(postgres_conn_id=postgres_conn_id)
     postgres.bulk_load(f'{load_table}', tsv_file_name)
-    postgres.run(
+    _clean_intermediate_table_data(postgres, load_table)
+
+
+def _clean_intermediate_table_data(
+        postgres_hook,
+        load_table
+):
+    postgres_hook.run(
         f'DELETE FROM {load_table} WHERE url IS NULL;'
     )
-    postgres.run(
+    postgres_hook.run(
         f'DELETE FROM {load_table} WHERE license IS NULL;'
     )
-    postgres.run(
+    postgres_hook.run(
         f'DELETE FROM {load_table} WHERE foreign_landing_url IS NULL;'
     )
-    postgres.run(
+    postgres_hook.run(
         f'DELETE FROM {load_table} WHERE foreign_identifier IS NULL;'
     )
-    postgres.run(
+    postgres_hook.run(
         f'DELETE FROM {load_table} p1'
         f' USING {load_table} p2'
         f' WHERE p1.ctid < p2.ctid'

--- a/src/cc_catalog_airflow/dags/util/loader/test_s3.py
+++ b/src/cc_catalog_airflow/dags/util/loader/test_s3.py
@@ -1,8 +1,6 @@
 import os
 from unittest.mock import patch
 
-import boto3
-
 from util.loader import s3
 
 TEST_ID = 'testing'
@@ -17,11 +15,13 @@ def test_copy_file_to_s3_staging_uses_connection_id():
     staging_prefix = TEST_STAGING_PREFIX
     tsv_file_path = '/test/file/path/to/data.tsv'
     aws_conn_id = 'test_conn_id'
+    test_bucket_name = 'test-bucket'
 
     with patch.object(s3, 'S3Hook') as mock_s3:
         s3.copy_file_to_s3_staging(
             identifier,
             tsv_file_path,
+            test_bucket_name,
             aws_conn_id,
             media_prefix=media_prefix,
             staging_prefix=staging_prefix
@@ -45,6 +45,7 @@ def test_copy_file_to_s3_staging_uses_bucket_environ(monkeypatch):
         s3.copy_file_to_s3_staging(
             identifier,
             tsv_file_path,
+            test_bucket_name,
             aws_conn_id,
             media_prefix=media_prefix,
             staging_prefix=staging_prefix
@@ -73,10 +74,10 @@ def test_copy_file_to_s3_staging_given_bucket_name(monkeypatch):
         s3.copy_file_to_s3_staging(
             identifier,
             tsv_file_path,
+            test_bucket_name,
             aws_conn_id,
             media_prefix=media_prefix,
-            staging_prefix=staging_prefix,
-            s3_bucket=test_bucket_name
+            staging_prefix=staging_prefix
         )
     print(mock_s3_load_file.mock_calls)
     print(mock_s3_load_file.method_calls)

--- a/src/cc_catalog_airflow/dags/util/loader/test_s3.py
+++ b/src/cc_catalog_airflow/dags/util/loader/test_s3.py
@@ -1,5 +1,7 @@
 import os
+import socket
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import boto3
 import pytest
@@ -14,10 +16,11 @@ S3_LOCAL_ENDPOINT = os.getenv('S3_LOCAL_ENDPOINT')
 S3_TEST_BUCKET = f'cccatalog-storage-{TEST_ID}'
 ACCESS_KEY = os.getenv('TEST_ACCESS_KEY')
 SECRET_KEY = os.getenv('TEST_SECRET_KEY')
+S3_HOST = socket.gethostbyname(urlparse(S3_LOCAL_ENDPOINT).hostname)
 
 
 @pytest.fixture
-def empty_s3_bucket():
+def empty_s3_bucket(socket_enabled):
     bucket = boto3.resource(
         's3',
         aws_access_key_id=ACCESS_KEY,
@@ -115,6 +118,7 @@ def test_copy_file_to_s3_staging_given_bucket_name():
     )
 
 
+@pytest.mark.allow_hosts([S3_HOST])
 def test_get_staged_s3_object_finds_object_with_defaults(empty_s3_bucket):
     media_prefix = s3.DEFAULT_MEDIA_PREFIX
     staging_prefix = s3.STAGING_PREFIX
@@ -130,6 +134,7 @@ def test_get_staged_s3_object_finds_object_with_defaults(empty_s3_bucket):
     assert actual_key == test_key
 
 
+@pytest.mark.allow_hosts([S3_HOST])
 def test_get_staged_s3_object_finds_object_with_givens(empty_s3_bucket):
     media_prefix = TEST_MEDIA_PREFIX
     staging_prefix = TEST_STAGING_PREFIX
@@ -147,6 +152,7 @@ def test_get_staged_s3_object_finds_object_with_givens(empty_s3_bucket):
     assert actual_key == test_key
 
 
+@pytest.mark.allow_hosts([S3_HOST])
 def test_get_staged_s3_object_complains_with_multiple_keys(empty_s3_bucket):
     media_prefix = TEST_MEDIA_PREFIX
     staging_prefix = TEST_STAGING_PREFIX

--- a/src/cc_catalog_airflow/dags/util/loader/test_s3.py
+++ b/src/cc_catalog_airflow/dags/util/loader/test_s3.py
@@ -1,12 +1,41 @@
 import os
 from unittest.mock import patch
 
+import boto3
+import pytest
+
 from util.loader import s3
 
 TEST_ID = 'testing'
 TEST_MEDIA_PREFIX = 'media'
 TEST_STAGING_PREFIX = 'test_staging'
 AWS_CONN_ID = os.getenv('AWS_TEST_CONN_ID')
+S3_LOCAL_ENDPOINT = os.getenv('S3_LOCAL_ENDPOINT')
+S3_TEST_BUCKET = f'cccatalog-storage-{TEST_ID}'
+ACCESS_KEY = os.getenv('TEST_ACCESS_KEY')
+SECRET_KEY = os.getenv('TEST_SECRET_KEY')
+
+
+@pytest.fixture
+def empty_s3_bucket():
+    bucket = boto3.resource(
+        's3',
+        aws_access_key_id=ACCESS_KEY,
+        aws_secret_access_key=SECRET_KEY,
+        endpoint_url=S3_LOCAL_ENDPOINT
+    ).Bucket(S3_TEST_BUCKET)
+
+    def _delete_all_objects():
+        key_list = [{'Key': obj.key} for obj in bucket.objects.all()]
+        if len(list(bucket.objects.all())) > 0:
+            bucket.delete_objects(Delete={'Objects': key_list})
+
+    if bucket.creation_date:
+        _delete_all_objects()
+    else:
+        bucket.create()
+    yield bucket
+    _delete_all_objects()
 
 
 def test_copy_file_to_s3_staging_uses_connection_id():
@@ -57,14 +86,12 @@ def test_copy_file_to_s3_staging_uses_bucket_environ(monkeypatch):
     )
 
 
-def test_copy_file_to_s3_staging_given_bucket_name(monkeypatch):
+def test_copy_file_to_s3_staging_given_bucket_name():
     identifier = TEST_ID
     media_prefix = TEST_MEDIA_PREFIX
     staging_prefix = TEST_STAGING_PREFIX
     tsv_file_path = '/test/file/path/to/data.tsv'
     aws_conn_id = 'test_conn_id'
-    test_bucket_env = 'test-bucket'
-    monkeypatch.setenv('CCCATALOG_STORAGE_BUCKET', test_bucket_env)
     test_bucket_name = 'test-bucket-given'
 
     with patch.object(
@@ -86,3 +113,55 @@ def test_copy_file_to_s3_staging_given_bucket_name(monkeypatch):
         f'{media_prefix}/{staging_prefix}/{identifier}/data.tsv',
         bucket_name=test_bucket_name
     )
+
+
+def test_get_staged_s3_object_finds_object_with_defaults(empty_s3_bucket):
+    media_prefix = s3.DEFAULT_MEDIA_PREFIX
+    staging_prefix = s3.STAGING_PREFIX
+    identifier = TEST_ID
+    file_name = 'data.tsv'
+    test_key = '/'.join([media_prefix, staging_prefix, identifier, file_name])
+    empty_s3_bucket.put_object(Key=test_key)
+    actual_key = s3.get_staged_s3_object(
+        identifier,
+        empty_s3_bucket.name,
+        AWS_CONN_ID
+    )
+    assert actual_key == test_key
+
+
+def test_get_staged_s3_object_finds_object_with_givens(empty_s3_bucket):
+    media_prefix = TEST_MEDIA_PREFIX
+    staging_prefix = TEST_STAGING_PREFIX
+    identifier = TEST_ID
+    file_name = 'data.tsv'
+    test_key = '/'.join([media_prefix, staging_prefix, identifier, file_name])
+    empty_s3_bucket.put_object(Key=test_key)
+    actual_key = s3.get_staged_s3_object(
+        identifier,
+        empty_s3_bucket.name,
+        AWS_CONN_ID,
+        media_prefix=media_prefix,
+        staging_prefix=staging_prefix
+    )
+    assert actual_key == test_key
+
+
+def test_get_staged_s3_object_complains_with_multiple_keys(empty_s3_bucket):
+    media_prefix = TEST_MEDIA_PREFIX
+    staging_prefix = TEST_STAGING_PREFIX
+    identifier = TEST_ID
+    file_1 = 'data.tsv'
+    file_2 = 'datb.tsv'
+    test_key_1 = '/'.join([media_prefix, staging_prefix, identifier, file_1])
+    test_key_2 = '/'.join([media_prefix, staging_prefix, identifier, file_2])
+    empty_s3_bucket.put_object(Key=test_key_1)
+    empty_s3_bucket.put_object(Key=test_key_2)
+    with pytest.raises(AssertionError):
+        s3.get_staged_s3_object(
+            identifier,
+            empty_s3_bucket.name,
+            AWS_CONN_ID,
+            media_prefix=media_prefix,
+            staging_prefix=staging_prefix
+        )

--- a/src/cc_catalog_airflow/dags/util/loader/test_sql.py
+++ b/src/cc_catalog_airflow/dags/util/loader/test_sql.py
@@ -3,6 +3,7 @@ import json
 import os
 import time
 
+import boto3
 import psycopg2
 import pytest
 
@@ -13,6 +14,10 @@ POSTGRES_CONN_ID = os.getenv('TEST_CONN_ID')
 POSTGRES_TEST_URI = os.getenv('AIRFLOW_CONN_POSTGRES_OPENLEDGER_TESTING')
 TEST_LOAD_TABLE = f'provider_image_data{TEST_ID}'
 TEST_IMAGE_TABLE = f'image_{TEST_ID}'
+S3_LOCAL_ENDPOINT = os.getenv('S3_LOCAL_ENDPOINT')
+S3_TEST_BUCKET = f'cccatalog-storage-{TEST_ID}'
+ACCESS_KEY = os.getenv('TEST_ACCESS_KEY')
+SECRET_KEY = os.getenv('TEST_SECRET_KEY')
 
 
 RESOURCES = os.path.join(
@@ -155,6 +160,60 @@ def postgres_with_load_and_image_table():
     conn.close()
 
 
+@pytest.fixture
+def empty_s3_bucket():
+    bucket = boto3.resource(
+        's3',
+        aws_access_key_id=ACCESS_KEY,
+        aws_secret_access_key=SECRET_KEY,
+        endpoint_url=S3_LOCAL_ENDPOINT
+    ).Bucket(S3_TEST_BUCKET)
+
+    def _delete_all_objects():
+        key_list = [{'Key': obj.key} for obj in bucket.objects.all()]
+        if len(list(bucket.objects.all())) > 0:
+            bucket.delete_objects(Delete={'Objects': key_list})
+
+    if bucket.creation_date:
+        _delete_all_objects()
+    else:
+        bucket.create()
+    yield bucket
+    _delete_all_objects()
+
+
+def _load_local_tsv(tmpdir, bucket, tsv_file_name):
+    """
+    This wraps sql.load_local_data_to_intermediate_table so we can test it
+    under various conditions.
+    """
+    tsv_file_path = os.path.join(RESOURCES, tsv_file_name)
+    with open(tsv_file_path) as f:
+        f_data = f.read()
+
+    test_tsv = 'test.tsv'
+    path = tmpdir.join(test_tsv)
+    path.write(f_data)
+
+    sql.load_local_data_to_intermediate_table(
+        POSTGRES_CONN_ID,
+        str(path),
+        TEST_ID
+    )
+
+
+def _load_s3_tsv(tmpdir, bucket, tsv_file_name):
+    tsv_file_path = os.path.join(RESOURCES, tsv_file_name)
+    key = 'path/to/object/{tsv_file_name}'
+    bucket.upload_file(tsv_file_path, key)
+    sql.load_s3_data_to_intermediate_table(
+        POSTGRES_CONN_ID,
+        S3_TEST_BUCKET,
+        key,
+        TEST_ID
+    )
+
+
 def test_create_loading_table_creates_table(postgres):
     postgres_conn_id = POSTGRES_CONN_ID
     identifier = TEST_ID
@@ -178,16 +237,28 @@ def test_create_loading_table_errors_if_run_twice_with_same_id(postgres):
         sql.create_loading_table(postgres_conn_id, identifier)
 
 
-def test_import_data_loads_good_tsv(postgres_with_load_table, tmpdir):
-    _load_local_tsv(tmpdir, 'none_missing.tsv')
+@pytest.mark.parametrize('load_function', [_load_local_tsv, _load_s3_tsv])
+def test_loaders_load_good_tsv(
+        postgres_with_load_table,
+        tmpdir,
+        empty_s3_bucket,
+        load_function
+):
+    load_function(tmpdir, empty_s3_bucket, 'none_missing.tsv')
     check_query = f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE};'
     postgres_with_load_table.cursor.execute(check_query)
     num_rows = postgres_with_load_table.cursor.fetchone()[0]
     assert num_rows == 10
 
 
-def test_import_data_deletes_null_url_rows(postgres_with_load_table, tmpdir):
-    _load_local_tsv(tmpdir, 'url_missing.tsv')
+@pytest.mark.parametrize('load_function', [_load_local_tsv, _load_s3_tsv])
+def test_loaders_delete_null_url_rows(
+        postgres_with_load_table,
+        tmpdir,
+        empty_s3_bucket,
+        load_function
+):
+    load_function(tmpdir, empty_s3_bucket, 'url_missing.tsv')
     null_url_check = (
         f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE} WHERE url IS NULL;'
     )
@@ -201,10 +272,14 @@ def test_import_data_deletes_null_url_rows(postgres_with_load_table, tmpdir):
     assert remaining_rows == 2
 
 
-def test_import_data_deletes_null_license_rows(
-        postgres_with_load_table, tmpdir
+@pytest.mark.parametrize('load_function', [_load_local_tsv, _load_s3_tsv])
+def test_loaders_delete_null_license_rows(
+        postgres_with_load_table,
+        tmpdir,
+        empty_s3_bucket,
+        load_function
 ):
-    _load_local_tsv(tmpdir, 'license_missing.tsv')
+    load_function(tmpdir, empty_s3_bucket, 'license_missing.tsv')
     license_check = (
         f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE} WHERE license IS NULL;'
     )
@@ -218,10 +293,14 @@ def test_import_data_deletes_null_license_rows(
     assert remaining_rows == 2
 
 
-def test_import_data_deletes_null_foreign_landing_url_rows(
-        postgres_with_load_table, tmpdir
+@pytest.mark.parametrize('load_function', [_load_local_tsv, _load_s3_tsv])
+def test_loaders_delete_null_foreign_landing_url_rows(
+        postgres_with_load_table,
+        tmpdir,
+        empty_s3_bucket,
+        load_function
 ):
-    _load_local_tsv(tmpdir, 'foreign_landing_url_missing.tsv')
+    load_function(tmpdir, empty_s3_bucket, 'foreign_landing_url_missing.tsv')
     foreign_landing_url_check = (
         f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE} '
         f'WHERE foreign_landing_url IS NULL;'
@@ -238,10 +317,14 @@ def test_import_data_deletes_null_foreign_landing_url_rows(
     assert remaining_rows == 3
 
 
-def test_import_data_deletes_null_foreign_identifier_rows(
-        postgres_with_load_table, tmpdir
+@pytest.mark.parametrize('load_function', [_load_local_tsv, _load_s3_tsv])
+def test_data_loaders_delete_null_foreign_identifier_rows(
+        postgres_with_load_table,
+        tmpdir,
+        empty_s3_bucket,
+        load_function
 ):
-    _load_local_tsv(tmpdir, 'foreign_identifier_missing.tsv')
+    load_function(tmpdir, empty_s3_bucket, 'foreign_identifier_missing.tsv')
     foreign_identifier_check = (
         f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE} '
         f'WHERE foreign_identifier IS NULL;'
@@ -258,10 +341,14 @@ def test_import_data_deletes_null_foreign_identifier_rows(
     assert remaining_rows == 1
 
 
+@pytest.mark.parametrize('load_function', [_load_local_tsv, _load_s3_tsv])
 def test_import_data_deletes_duplicate_foreign_identifier_rows(
-        postgres_with_load_table, tmpdir
+        postgres_with_load_table,
+        tmpdir,
+        empty_s3_bucket,
+        load_function
 ):
-    _load_local_tsv(tmpdir, 'foreign_identifier_duplicate.tsv')
+    load_function(tmpdir, empty_s3_bucket, 'foreign_identifier_duplicate.tsv')
     foreign_id_duplicate_check = (
         f"SELECT COUNT (*) FROM {TEST_LOAD_TABLE} "
         f"WHERE foreign_identifier='135257';"
@@ -276,26 +363,6 @@ def test_import_data_deletes_duplicate_foreign_identifier_rows(
 
     assert foreign_id_duplicate_num_rows == 1
     assert remaining_rows == 3
-
-
-def _load_local_tsv(tmpdir, tsv_file_name):
-    """
-    This wraps sql.load_local_data_to_intermediate_table so we can test it
-    under various conditions.
-    """
-    tsv_file_path = os.path.join(RESOURCES, tsv_file_name)
-    with open(tsv_file_path) as f:
-        f_data = f.read()
-
-    test_tsv = 'test.tsv'
-    path = tmpdir.join(test_tsv)
-    path.write(f_data)
-
-    sql.load_local_data_to_intermediate_table(
-        POSTGRES_CONN_ID,
-        str(path),
-        TEST_ID
-    )
 
 
 def test_upsert_records_inserts_one_record_to_empty_image_table(

--- a/src/cc_catalog_airflow/dags/util/loader/test_sql.py
+++ b/src/cc_catalog_airflow/dags/util/loader/test_sql.py
@@ -1,7 +1,10 @@
 from collections import namedtuple
 import json
 import os
+import socket
 import time
+from urllib.parse import urlparse
+
 
 import boto3
 import psycopg2
@@ -18,6 +21,7 @@ S3_LOCAL_ENDPOINT = os.getenv('S3_LOCAL_ENDPOINT')
 S3_TEST_BUCKET = f'cccatalog-storage-{TEST_ID}'
 ACCESS_KEY = os.getenv('TEST_ACCESS_KEY')
 SECRET_KEY = os.getenv('TEST_SECRET_KEY')
+S3_HOST = socket.gethostbyname(urlparse(S3_LOCAL_ENDPOINT).hostname)
 
 
 RESOURCES = os.path.join(
@@ -161,7 +165,7 @@ def postgres_with_load_and_image_table():
 
 
 @pytest.fixture
-def empty_s3_bucket():
+def empty_s3_bucket(socket_enabled):
     bucket = boto3.resource(
         's3',
         aws_access_key_id=ACCESS_KEY,
@@ -238,6 +242,7 @@ def test_create_loading_table_errors_if_run_twice_with_same_id(postgres):
 
 
 @pytest.mark.parametrize('load_function', [_load_local_tsv, _load_s3_tsv])
+@pytest.mark.allow_hosts([S3_HOST])
 def test_loaders_load_good_tsv(
         postgres_with_load_table,
         tmpdir,
@@ -252,6 +257,7 @@ def test_loaders_load_good_tsv(
 
 
 @pytest.mark.parametrize('load_function', [_load_local_tsv, _load_s3_tsv])
+@pytest.mark.allow_hosts([S3_HOST])
 def test_loaders_delete_null_url_rows(
         postgres_with_load_table,
         tmpdir,
@@ -273,6 +279,7 @@ def test_loaders_delete_null_url_rows(
 
 
 @pytest.mark.parametrize('load_function', [_load_local_tsv, _load_s3_tsv])
+@pytest.mark.allow_hosts([S3_HOST])
 def test_loaders_delete_null_license_rows(
         postgres_with_load_table,
         tmpdir,
@@ -294,6 +301,7 @@ def test_loaders_delete_null_license_rows(
 
 
 @pytest.mark.parametrize('load_function', [_load_local_tsv, _load_s3_tsv])
+@pytest.mark.allow_hosts([S3_HOST])
 def test_loaders_delete_null_foreign_landing_url_rows(
         postgres_with_load_table,
         tmpdir,
@@ -318,6 +326,7 @@ def test_loaders_delete_null_foreign_landing_url_rows(
 
 
 @pytest.mark.parametrize('load_function', [_load_local_tsv, _load_s3_tsv])
+@pytest.mark.allow_hosts([S3_HOST])
 def test_data_loaders_delete_null_foreign_identifier_rows(
         postgres_with_load_table,
         tmpdir,
@@ -342,6 +351,7 @@ def test_data_loaders_delete_null_foreign_identifier_rows(
 
 
 @pytest.mark.parametrize('load_function', [_load_local_tsv, _load_s3_tsv])
+@pytest.mark.allow_hosts([S3_HOST])
 def test_import_data_deletes_duplicate_foreign_identifier_rows(
         postgres_with_load_table,
         tmpdir,

--- a/src/cc_catalog_airflow/dags/util/loader/test_sql.py
+++ b/src/cc_catalog_airflow/dags/util/loader/test_sql.py
@@ -179,49 +179,21 @@ def test_create_loading_table_errors_if_run_twice_with_same_id(postgres):
 
 
 def test_import_data_loads_good_tsv(postgres_with_load_table, tmpdir):
-    postgres_conn_id = POSTGRES_CONN_ID
-    identifier = TEST_ID
-    load_table = TEST_LOAD_TABLE
-    tsv_file_name = os.path.join(RESOURCES, 'none_missing.tsv')
-    with open(tsv_file_name) as f:
-        f_data = f.read()
-
-    test_tsv = 'test.tsv'
-    path = tmpdir.join(test_tsv)
-    path.write(f_data)
-
-    sql.import_data_to_intermediate_table(
-        postgres_conn_id,
-        str(path),
-        identifier
-    )
-    check_query = f'SELECT COUNT (*) FROM {load_table};'
+    _load_local_tsv(tmpdir, 'none_missing.tsv')
+    check_query = f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE};'
     postgres_with_load_table.cursor.execute(check_query)
     num_rows = postgres_with_load_table.cursor.fetchone()[0]
     assert num_rows == 10
 
 
 def test_import_data_deletes_null_url_rows(postgres_with_load_table, tmpdir):
-    postgres_conn_id = POSTGRES_CONN_ID
-    identifier = TEST_ID
-    load_table = TEST_LOAD_TABLE
-    tsv_file_name = os.path.join(RESOURCES, 'url_missing.tsv')
-    with open(tsv_file_name) as f:
-        f_data = f.read()
-
-    test_tsv = 'test.tsv'
-    path = tmpdir.join(test_tsv)
-    path.write(f_data)
-
-    sql.import_data_to_intermediate_table(
-        postgres_conn_id,
-        str(path),
-        identifier
+    _load_local_tsv(tmpdir, 'url_missing.tsv')
+    null_url_check = (
+        f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE} WHERE url IS NULL;'
     )
-    null_url_check = f'SELECT COUNT (*) FROM {load_table} WHERE url IS NULL;'
     postgres_with_load_table.cursor.execute(null_url_check)
     null_url_num_rows = postgres_with_load_table.cursor.fetchone()[0]
-    remaining_row_count = f'SELECT COUNT (*) FROM {load_table};'
+    remaining_row_count = f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE};'
     postgres_with_load_table.cursor.execute(remaining_row_count)
     remaining_rows = postgres_with_load_table.cursor.fetchone()[0]
 
@@ -232,28 +204,13 @@ def test_import_data_deletes_null_url_rows(postgres_with_load_table, tmpdir):
 def test_import_data_deletes_null_license_rows(
         postgres_with_load_table, tmpdir
 ):
-    postgres_conn_id = POSTGRES_CONN_ID
-    identifier = TEST_ID
-    load_table = TEST_LOAD_TABLE
-    tsv_file_name = os.path.join(RESOURCES, 'license_missing.tsv')
-    with open(tsv_file_name) as f:
-        f_data = f.read()
-
-    test_tsv = 'test.tsv'
-    path = tmpdir.join(test_tsv)
-    path.write(f_data)
-
-    sql.import_data_to_intermediate_table(
-        postgres_conn_id,
-        str(path),
-        identifier
-    )
+    _load_local_tsv(tmpdir, 'license_missing.tsv')
     license_check = (
-        f'SELECT COUNT (*) FROM {load_table} WHERE license IS NULL;'
+        f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE} WHERE license IS NULL;'
     )
     postgres_with_load_table.cursor.execute(license_check)
     null_license_num_rows = postgres_with_load_table.cursor.fetchone()[0]
-    remaining_row_count = f'SELECT COUNT (*) FROM {load_table};'
+    remaining_row_count = f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE};'
     postgres_with_load_table.cursor.execute(remaining_row_count)
     remaining_rows = postgres_with_load_table.cursor.fetchone()[0]
 
@@ -264,31 +221,16 @@ def test_import_data_deletes_null_license_rows(
 def test_import_data_deletes_null_foreign_landing_url_rows(
         postgres_with_load_table, tmpdir
 ):
-    postgres_conn_id = POSTGRES_CONN_ID
-    identifier = TEST_ID
-    load_table = TEST_LOAD_TABLE
-    tsv_file_name = os.path.join(RESOURCES, 'foreign_landing_url_missing.tsv')
-    with open(tsv_file_name) as f:
-        f_data = f.read()
-
-    test_tsv = 'test.tsv'
-    path = tmpdir.join(test_tsv)
-    path.write(f_data)
-
-    sql.import_data_to_intermediate_table(
-        postgres_conn_id,
-        str(path),
-        identifier
-    )
+    _load_local_tsv(tmpdir, 'foreign_landing_url_missing.tsv')
     foreign_landing_url_check = (
-        f'SELECT COUNT (*) FROM {load_table} '
+        f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE} '
         f'WHERE foreign_landing_url IS NULL;'
     )
     postgres_with_load_table.cursor.execute(foreign_landing_url_check)
     null_foreign_landing_url_num_rows = (
         postgres_with_load_table.cursor.fetchone()[0]
     )
-    remaining_row_count = f'SELECT COUNT (*) FROM {load_table};'
+    remaining_row_count = f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE};'
     postgres_with_load_table.cursor.execute(remaining_row_count)
     remaining_rows = postgres_with_load_table.cursor.fetchone()[0]
 
@@ -299,31 +241,16 @@ def test_import_data_deletes_null_foreign_landing_url_rows(
 def test_import_data_deletes_null_foreign_identifier_rows(
         postgres_with_load_table, tmpdir
 ):
-    postgres_conn_id = POSTGRES_CONN_ID
-    identifier = TEST_ID
-    load_table = TEST_LOAD_TABLE
-    tsv_file_name = os.path.join(RESOURCES, 'foreign_identifier_missing.tsv')
-    with open(tsv_file_name) as f:
-        f_data = f.read()
-
-    test_tsv = 'test.tsv'
-    path = tmpdir.join(test_tsv)
-    path.write(f_data)
-
-    sql.import_data_to_intermediate_table(
-        postgres_conn_id,
-        str(path),
-        identifier
-    )
+    _load_local_tsv(tmpdir, 'foreign_identifier_missing.tsv')
     foreign_identifier_check = (
-        f'SELECT COUNT (*) FROM {load_table} '
+        f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE} '
         f'WHERE foreign_identifier IS NULL;'
     )
     postgres_with_load_table.cursor.execute(foreign_identifier_check)
     null_foreign_identifier_num_rows = (
         postgres_with_load_table.cursor.fetchone()[0]
     )
-    remaining_row_count = f'SELECT COUNT (*) FROM {load_table};'
+    remaining_row_count = f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE};'
     postgres_with_load_table.cursor.execute(remaining_row_count)
     remaining_rows = postgres_with_load_table.cursor.fetchone()[0]
 
@@ -334,36 +261,41 @@ def test_import_data_deletes_null_foreign_identifier_rows(
 def test_import_data_deletes_duplicate_foreign_identifier_rows(
         postgres_with_load_table, tmpdir
 ):
-    postgres_conn_id = POSTGRES_CONN_ID
-    identifier = TEST_ID
-    load_table = TEST_LOAD_TABLE
-    tsv_file_name = os.path.join(RESOURCES, 'foreign_identifier_duplicate.tsv')
-    with open(tsv_file_name) as f:
-        f_data = f.read()
-
-    test_tsv = 'test.tsv'
-    path = tmpdir.join(test_tsv)
-    path.write(f_data)
-
-    sql.import_data_to_intermediate_table(
-        postgres_conn_id,
-        str(path),
-        identifier
-    )
+    _load_local_tsv(tmpdir, 'foreign_identifier_duplicate.tsv')
     foreign_id_duplicate_check = (
-        f"SELECT COUNT (*) FROM {load_table} "
+        f"SELECT COUNT (*) FROM {TEST_LOAD_TABLE} "
         f"WHERE foreign_identifier='135257';"
     )
     postgres_with_load_table.cursor.execute(foreign_id_duplicate_check)
     foreign_id_duplicate_num_rows = (
         postgres_with_load_table.cursor.fetchone()[0]
     )
-    remaining_row_count = f'SELECT COUNT (*) FROM {load_table};'
+    remaining_row_count = f'SELECT COUNT (*) FROM {TEST_LOAD_TABLE};'
     postgres_with_load_table.cursor.execute(remaining_row_count)
     remaining_rows = postgres_with_load_table.cursor.fetchone()[0]
 
     assert foreign_id_duplicate_num_rows == 1
     assert remaining_rows == 3
+
+
+def _load_local_tsv(tmpdir, tsv_file_name):
+    """
+    This wraps sql.load_local_data_to_intermediate_table so we can test it
+    under various conditions.
+    """
+    tsv_file_path = os.path.join(RESOURCES, tsv_file_name)
+    with open(tsv_file_path) as f:
+        f_data = f.read()
+
+    test_tsv = 'test.tsv'
+    path = tmpdir.join(test_tsv)
+    path.write(f_data)
+
+    sql.load_local_data_to_intermediate_table(
+        POSTGRES_CONN_ID,
+        str(path),
+        TEST_ID
+    )
 
 
 def test_upsert_records_inserts_one_record_to_empty_image_table(

--- a/src/cc_catalog_airflow/docker-compose.yml
+++ b/src/cc_catalog_airflow/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - POSTGRES_USER=deploy
       - POSTGRES_PASSWORD=deploy
       - POSTGRES_DB=openledger
+    env_file: .env
     ports:
       - "5432:5432"
     volumes:

--- a/src/cc_catalog_airflow/env.template
+++ b/src/cc_catalog_airflow/env.template
@@ -7,8 +7,10 @@ THINGIVERSE_TOKEN=not_set
 WM_SCRIPT_CONTACT=cc.catalog@creativecommons.org
 
 S3_BUCKET=not_set
-AWS_ACCESS_KEY=not_set
-AWS_SECRET_KEY=not_set
+AWS_ACCESS_KEY=test_key
+AWS_SECRET_KEY=test_secret
+TEST_ACCESS_KEY=test_key
+TEST_SECRET_KEY=test_secret
 
 # Change the following line in prod to use the appropriate DB
 AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
@@ -26,6 +28,7 @@ AIRFLOW_CONN_POSTGRES_OPENLEDGER_TESTING=postgres://deploy:deploy@postgres:5432/
 OPENLEDGER_CONN_ID=postgres_openledger_upstream
 TEST_CONN_ID=postgres_openledger_testing
 
+S3_LOCAL_ENDPOINT=http://s3:5000
 AIRFLOW_CONN_AWS_PROD=aws://test_key:test_secret@?region_name=us-east-1&host=http://s3:5000
 AIRFLOW_CONN_AWS_TEST=aws://test_key:test_secret@?region_name=us-east-1&host=http://s3:5000
 

--- a/src/cc_catalog_airflow/local_postgres/Dockerfile
+++ b/src/cc_catalog_airflow/local_postgres/Dockerfile
@@ -3,4 +3,6 @@ ENV POSTGRES_USER=deploy
 ENV POSTGRES_PASSWORD=deploy
 ENV POSTGRES_DB=openledger
 ADD ./openledger_image_schema.sql /docker-entrypoint-initdb.d
+ADD ./aws_s3_mock.sql /docker-entrypoint-initdb.d
 ADD ./airflow_user_db.sql /docker-entrypoint-initdb.d
+RUN apt-get -y update && apt-get -y install python3-boto3 postgresql-plpython3-10

--- a/src/cc_catalog_airflow/local_postgres/aws_s3_mock.sql
+++ b/src/cc_catalog_airflow/local_postgres/aws_s3_mock.sql
@@ -1,0 +1,37 @@
+CREATE SCHEMA IF NOT EXISTS aws_s3;
+CREATE LANGUAGE plpython3u;
+
+CREATE OR REPLACE FUNCTION aws_s3.table_import_from_s3 (
+  table_name text,
+  column_list text,
+  options text,
+  bucket text,
+  file_path text,
+  region text
+) RETURNS int
+LANGUAGE plpython3u
+AS $$
+    import os
+    import boto3
+    s3_obj = boto3.resource(
+        's3',
+        aws_access_key_id=os.getenv('AWS_ACCESS_KEY', 'test_key'),
+        aws_secret_access_key=os.getenv('AWS_SECRET_KEY', 'test_secret'),
+        region_name=region,
+        endpoint_url=os.getenv('S3_LOCAL_ENDPOINT', 'http://s3:5000')
+    ).Object(bucket, file_path)
+    temp_location = '/tmp/postgres_loading.tsv'
+    s3_obj.download_file(temp_location)
+    with open(temp_location) as f:
+        columns = '({})'.format(column_list) if column_list else ''
+        res = plpy.execute(
+            'COPY {} {} FROM {} {};'.format(
+                table_name,
+                columns,
+                plpy.quote_literal(temp_location),
+                options
+            )
+        )
+    os.remove(temp_location)
+    return res.nrows()
+$$;


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #334  by @mathemancer 
## Description
<!-- Concisely describe what the pull request does. -->
This PR modifies the Apache Airflow DAG (Directed Acyclic Graph) defined at src/cc_catalog_airflow/dags/loader_workflow.py so that it now loads the staged TSV (tab separated value) from an AWS S3 bucket to PostgreSQL, and deletes the local copy (on the EC2 instance) in any case, as long as it's managed to copy the data off of the machine.

The DAG now tries two ways to get the data off of the machine:
1. Try to upload the TSV file to S3.
2. If loading from S3 to PostgreSQL fails for some reason, try to load the local copy to PostgreSQL.
If either of these attempts succeeds, we delete the local copy to free disk space on the EC2.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
- We'll still archive the TSV file locally in the case where we can't get it into either S3 or Postgres.


## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Follow the instructions in the `README.md` to run the tests.  For even more excitement:
1. Login to the `cc_catalog_airflow_webserver_1` container (after following the `README.md` to bring up the environment):
```shell
docker exec -it cc_catalog_airflow_webserver_1 /bin/bash
```
2. Copy an example tsv to the `/tmp/` directory in the container:
```shell
cp /usr/local/airflow/dags/provider_api_scripts/tests/resources/example_output/phylopic_1561673410.tsv /tmp/
```
3. Go to `localhost:9090` in your browser, and toggle the `tsv_to_postgres_loader` DAG to 'On'
4. Click on the tiny 'tree' icon in the interface for that DAG.  Watch the lights turn green.  It may take a couple of runs before anything interesting happens, since the DAG waits for the file to be unmodified for a minute before it does anything.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] ~I added or updated documentation (if applicable).~
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
