### PR TITLE
Add Date Partitioned Wikimedia reingestion workflow

### DIFF
--- a/src/cc_catalog_airflow/dags/test_wikimedia_ingestion_workflow.py
+++ b/src/cc_catalog_airflow/dags/test_wikimedia_ingestion_workflow.py
@@ -1,0 +1,15 @@
+import os
+from airflow.models import DagBag
+
+FILE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
+def test_dag_loads_with_no_errors(tmpdir):
+    tmp_directory = str(tmpdir)
+    dag_bag = DagBag(dag_folder=tmp_directory, include_examples=False)
+    dag_bag.process_file(
+        os.path.join(FILE_DIR, 'wikimedia_ingestion_workflow.py')
+    )
+    print(dag_bag.dags)
+    assert len(dag_bag.import_errors) == 0
+    assert len(dag_bag.dags) == 1

--- a/src/cc_catalog_airflow/dags/wikimedia_ingestion_workflow.py
+++ b/src/cc_catalog_airflow/dags/wikimedia_ingestion_workflow.py
@@ -24,7 +24,7 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-DAG_ID = 'wikimedia_commons_ingestion_workflow'
+DAG_ID = 'wikimedia_ingestion_workflow'
 START_DATE = datetime(1970, 1, 1)
 INGESTION_TASK_TIMEOUT = timedelta(minutes=90)
 

--- a/src/cc_catalog_airflow/dags/wikimedia_ingestion_workflow.py
+++ b/src/cc_catalog_airflow/dags/wikimedia_ingestion_workflow.py
@@ -2,11 +2,11 @@
 This file configures the Apache Airflow DAG to ingest and reingest
 Wikimedia Commons data according to the following strategy:
 
-We run `flickr.main` with a number of different date parameters. For
-each of these parameters, `flickr.main` should ingest the metadata
-associated with photos uploaded on that date.  The dates to ingest are
-calculated using the `util.helpers.get_reingestion_day_list_list`
-method.
+We run `wikimedia_commons.main` with a number of different date
+parameters. For each of these parameters, `wikimedia_commons.main`
+should ingest the metadata associated with photos uploaded on that date.
+The dates to ingest are calculated using the
+`util.helpers.get_reingestion_day_list_list` method.
 """
 # airflow DAG (necessary for Airflow to find this file)
 

--- a/src/cc_catalog_airflow/dags/wikimedia_ingestion_workflow.py
+++ b/src/cc_catalog_airflow/dags/wikimedia_ingestion_workflow.py
@@ -1,0 +1,50 @@
+"""
+This file configures the Apache Airflow DAG to ingest and reingest
+Wikimedia Commons data according to the following strategy:
+
+We run `flickr.main` with a number of different date parameters. For
+each of these parameters, `flickr.main` should ingest the metadata
+associated with photos uploaded on that date.  The dates to ingest are
+calculated using the `util.helpers.get_reingestion_day_list_list`
+method.
+"""
+# airflow DAG (necessary for Airflow to find this file)
+
+from datetime import datetime, timedelta
+import logging
+
+from provider_api_scripts import wikimedia_commons
+from util.dag_factory import create_day_partitioned_ingestion_dag
+from util.helpers import get_reingestion_day_list_list
+
+logging.basicConfig(
+    format='%(asctime)s: [%(levelname)s - DAG Loader] %(message)s',
+    level=logging.DEBUG)
+
+
+logger = logging.getLogger(__name__)
+
+DAG_ID = 'wikimedia_commons_ingestion_workflow'
+START_DATE = datetime(1970, 1, 1)
+INGESTION_TASK_TIMEOUT = timedelta(minutes=90)
+
+DAILY_LIST_LENGTH = 6
+ONE_MONTH_LIST_LENGTH = 9
+THREE_MONTH_LIST_LENGTH = 18
+SIX_MONTH_LIST_LENGTH = 30
+
+reingestion_days = get_reingestion_day_list_list(
+    (1, DAILY_LIST_LENGTH),
+    (30, ONE_MONTH_LIST_LENGTH),
+    (90, THREE_MONTH_LIST_LENGTH),
+    (180, SIX_MONTH_LIST_LENGTH)
+)
+
+globals()[DAG_ID] = create_day_partitioned_ingestion_dag(
+    DAG_ID,
+    wikimedia_commons.main,
+    reingestion_days,
+    start_date=START_DATE,
+    concurrency=4,
+    ingestion_task_timeout=INGESTION_TASK_TIMEOUT
+)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #395 by @mathemancer 

## Description
<!-- Concisely describe what the pull request does. -->
This adds a new Apache Airflow DAG (Directed Acyclic Graph) that runs the Wikimedia Commons Provider API Script on a schedule to ingest metadata for the most recently uploaded images as well as older images.  The schedule is approximately:

- Ingest data which is at most a week old daily.
- Ingest data which is between a week and nine months old monthly.
- Ingest data which is between nine months and five years old every three months.
- Ingest data which is between five and twenty years old every six months.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
The more precise schedule is:

We ingest metadata for photos uploaded on the current `execution_date`, as well as metadata for photos uploaded

- 1, 2, ..., 5, or 6 days prior;
- 36, 66, ..., 246, or 276 days prior;
- 366, 456, ..., 1806, or 1896 days prior; and
- 2076, 2256, ..., 7116, or 7296 days prior.

The ingestion is done in the order of the list above, i.e., we prioritize ingesting the new data, then move on to ingesting older data.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

As always, there are tests which are run by Github Action, or the reviewer can follow the `README.md`, and go to the UI in their browser to see the new workflow.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] ~I added or updated documentation (if applicable).~
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
