### PR TITLE
add LOADER_FILE_AGE and DATA_GOV_API_KEY to env.template

### DIFF
--- a/src/cc_catalog_airflow/env.template
+++ b/src/cc_catalog_airflow/env.template
@@ -2,6 +2,7 @@
 OUTPUT_DIR=/tmp/
 
 BROOKLYN_MUSEUM_API_KEY=not_set
+DATA_GOV_API_KEY=not_set
 FLICKR_API_KEY=not_set
 THINGIVERSE_TOKEN=not_set
 WM_SCRIPT_CONTACT=cc.catalog@creativecommons.org
@@ -38,3 +39,4 @@ AWS_TEST_CONN_ID=aws_test
 CCCATALOG_STORAGE_BUCKET=cccatalog-storage
 
 AIRFLOW_PORT=9090
+LOADER_FILE_AGE=1


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #406 by @mathemancer 

## Description
<!-- Concisely describe what the pull request does. -->
Adds:
- `DATA_GOV_API_KEY=not_set` and
- `LOADER_FILE_AGE=1`
to `env.template`.

This will help remind developers to add a real `DATA_GOV_API_KEY` to their `.env` file for development if necessary.

Also, setting `LOADER_FILE_AGE=1` will make the `tsv_to_postgres_loader` Apache Airflow DAG pick up TSVs after only one minute rather than 15, which is more convenient for local testing.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

- Follow the `README.md` to setup the local development environment.
- note that `tsv_to_postgres_loader` will now pick up any files put in the `/tmp/` directory of the `cc_catalog_airflow_webserver_1` container after waiting only 1 minute.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] ~I added tests for the changes I made (if applicable).~
- [ ] ~I added or updated documentation (if applicable).~
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
