### PR TITLE
Improve logging in _get_image_pages

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
@@ -44,6 +44,12 @@ def test_get_image_pages_returns_correctly_with_none_json():
     assert actual_result == expect_result
 
 
+def test_get_image_pages_returns_correctly_with_no_pages():
+    expect_result = None
+    actual_result = wmc._get_image_pages({'batch_complete': ''})
+    assert actual_result == expect_result
+
+
 def test_build_query_params_adds_start_and_end():
     actual_qp = wmc._build_query_params(
         'abc', 'def', default_query_params={}

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -153,11 +153,14 @@ def _get_image_pages(image_batch):
     image_pages = None
 
     if image_batch is not None:
-        image_pages = image_batch.get('query', {}).get('pages', [])
+        image_pages = image_batch.get('query', {}).get('pages')
 
+    if image_pages is None:
+        logger.warning(f'No pages in the image_batch: {image_batch}')
+    else:
         logger.info(f'Got {len(image_pages)} pages')
 
-    return image_pages if image_pages else None
+    return image_pages
 
 
 def _process_image_pages(image_pages):

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -153,11 +153,11 @@ def _get_image_pages(image_batch):
     image_pages = None
 
     if image_batch is not None:
-        image_pages = image_batch.get('query', {}).get('pages')
+        image_pages = image_batch.get('query', {}).get('pages', [])
 
         logger.info(f'Got {len(image_pages)} pages')
 
-    return image_pages
+    return image_pages if image_pages else None
 
 
 def _process_image_pages(image_pages):


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #409 by @mathemancer 

## Description
<!-- Concisely describe what the pull request does. -->
Improves logging in the `wikimedia_commons._get_image_pages` function so that it doesn't cause an error when there is no `pages` field in the response JSON from Wikimedia Commons.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
There is a new test to test this functionality.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] ~I added or updated documentation (if applicable).~
- [ ] ~I tried running the project locally and verified that there are no
  visible errors.~

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
