### PR TITLE
Science Museum Provider API Script -- foreign id reference image uid

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/science_museum.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/science_museum.py
@@ -150,6 +150,9 @@ def _handle_object_data(batch_data):
         if multimedia is None:
             continue
         for image_data in multimedia:
+            foreign_id = image_data.get("admin", {}).get("uid")
+            if foreign_id is None:
+                continue
             processed = image_data.get("processed")
             source = image_data.get("source")
             image_url, height, width = _get_image_info(
@@ -165,7 +168,7 @@ def _handle_object_data(batch_data):
             license_ = license_.replace("cc-", "")
             thumbnail_url = _get_thumbnail_url(processed)
             image_count = image_store.add_item(
-                    foreign_identifier=id_,
+                    foreign_identifier=foreign_id,
                     foreign_landing_url=foreign_landing_url,
                     image_url=image_url,
                     height=height,


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #417  by @kss682 

## Description
<!-- Concisely describe what the pull request does. -->
foreign id in science museum now references the image ```uid``` present in mulltimedia. 

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
