### PR TITLE
modify output paths of DAGs, use Docker volume for persistence

### DIFF
--- a/src/cc_catalog_airflow/Dockerfile
+++ b/src/cc_catalog_airflow/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7-buster
 
 ENV AIRFLOW_HOME=/usr/local/airflow
-ARG OUTPUT_DIR=/tmp/
+ARG OUTPUT_DIR=/tmp/workflow_output/
 ENV PATH=/usr/local/airflow/.local/bin:$PATH
 
 RUN apt-get -yqq update \

--- a/src/cc_catalog_airflow/dags/popularity_workflow.py
+++ b/src/cc_catalog_airflow/dags/popularity_workflow.py
@@ -36,12 +36,13 @@ popularity_fields = [
 ]
 
 DB_CONN_ID = os.getenv('OPENLEDGER_CONN_ID', 'postgres_openledger_testing')
+POPULARITY_DIR = 'popularity_workflow'
 
 POPULARITY_DUMP_DEST = os.path.join(
-    os.getenv('OUTPUT_DIR'), 'popularity_dump.tsv'
+    os.getenv('OUTPUT_DIR'), POPULARITY_DIR, 'popularity_dump.tsv'
 )
 NORMALIZED_POPULARITY_DEST = os.path.join(
-    os.getenv('OUTPUT_DIR'), 'normalized_popularity_dump.tsv'
+    os.getenv('OUTPUT_DIR'), POPULARITY_DIR, 'normalized_popularity_dump.tsv'
 )
 
 
@@ -54,7 +55,9 @@ def main():
             open(NORMALIZED_POPULARITY_DEST, 'w+') as out_tsv:
         dump_selection_to_tsv(DB_CONN_ID, dump_query, POPULARITY_DUMP_DEST)
         log.info('Normalizing popularity data. . .')
-        generate_popularity_tsv(in_tsv, out_tsv, percentiles, popularity_fields)
+        generate_popularity_tsv(
+            in_tsv, out_tsv, percentiles, popularity_fields
+        )
         log.info('Finished normalizing popularity scores. Uploading. . .')
         upload_normalized_popularity(DB_CONN_ID, NORMALIZED_POPULARITY_DEST)
         log.info('Popularity normalization complete.')

--- a/src/cc_catalog_airflow/docker-compose.yml
+++ b/src/cc_catalog_airflow/docker-compose.yml
@@ -31,3 +31,8 @@ services:
       - s3
     ports:
       - "${AIRFLOW_PORT}:8080"
+    volumes:
+      - airflow-volume:/tmp/workflow_output
+
+volumes:
+  airflow-volume:


### PR DESCRIPTION
also write output files to volume for persistence between restarts

## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #437  by @mathemancer 

## Description
<!-- Concisely describe what the pull request does. -->
The Apache Airflow DAGs now keep their output files in a subdirectory of the `/tmp/` directory in the container, and each dag keeps its files in different subdirectories.

Also we now use a volume for persistence of output files between container restarts.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
The tests are still passing!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] ~I added tests for the changes I made (if applicable).~
- [ ] ~I added or updated documentation (if applicable).~
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
