### PR TITLE
Retrieve sub providers within Europeana

### DIFF
--- a/src/cc_catalog_airflow/dags/europeana_sub_provider_update_workflow.py
+++ b/src/cc_catalog_airflow/dags/europeana_sub_provider_update_workflow.py
@@ -1,0 +1,67 @@
+"""
+This file configures the Apache Airflow DAG to update the database table to
+reflect appropriate Europeana sub provider/ default provider names in the
+source field
+"""
+
+from datetime import datetime, timedelta
+import logging
+import os
+import util.operator_util as ops
+from airflow import DAG
+
+from util.loader import operators
+
+
+logging.basicConfig(
+    format='%(asctime)s - %(name)s - %(levelname)s:  %(message)s',
+    level=logging.INFO
+)
+
+logger = logging.getLogger(__name__)
+
+DAG_ID = 'europeana_sub_provider_update_workflow'
+DB_CONN_ID = os.getenv('OPENLEDGER_CONN_ID', 'postgres_openledger_testing')
+CONCURRENCY = 5
+
+DAG_DEFAULT_ARGS = {
+    'owner': 'data-eng-admin',
+    'depends_on_past': False,
+    'start_date': datetime(2020, 1, 15),
+    'email_on_retry': False,
+    'retries': 2,
+    'retry_delay': timedelta(seconds=15),
+    'schedule_interval': None,
+}
+
+
+def create_dag(
+        dag_id=DAG_ID,
+        args=DAG_DEFAULT_ARGS,
+        concurrency=CONCURRENCY,
+        max_active_runs=CONCURRENCY,
+        postgres_conn_id=DB_CONN_ID,
+):
+    dag = DAG(
+        dag_id=dag_id,
+        default_args=args,
+        concurrency=concurrency,
+        max_active_runs=max_active_runs,
+        catchup=False,
+        schedule_interval=None,
+    )
+
+    with dag:
+        start_task = ops.get_log_operator(dag, dag.dag_id, 'Starting')
+        run_task = operators.get_europeana_sub_provider_update_operator(
+          dag,
+          postgres_conn_id
+        )
+        end_task = ops.get_log_operator(dag, dag.dag_id, 'Finished')
+
+        start_task >> run_task >> end_task
+
+    return dag
+
+
+globals()[DAG_ID] = create_dag()

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/europeana.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/europeana.py
@@ -180,8 +180,13 @@ def _process_image_data(image_data, sub_providers=SUB_PROVIDERS,
     meta_data = _create_meta_data_dict(image_data)
 
     data_providers = set(meta_data['dataProvider'])
-    source = next((s for s in sub_providers if sub_providers[s] in
-                   data_providers), provider)
+    eligible_sub_providers = {s for s in sub_providers if sub_providers[s] in
+                              data_providers}
+    if len(eligible_sub_providers) > 1:
+        raise Exception(f"More than one sub-provider identified for the "
+                        f"image with foreign ID {foreign_id}")
+    source = eligible_sub_providers.pop() if len(eligible_sub_providers) == 1 \
+        else provider
 
     return image_store.add_item(
         foreign_landing_url=foreign_landing_url,

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_europeana.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_europeana.py
@@ -172,6 +172,7 @@ def test_process_image_data_with_real_example():
         foreign_identifier="/2022704/lod_oai_bibliotecadigital_jcyl_es_26229_ent1",
         title="Claustro del Monasterio de S. Salvador en Oña [Material gráfico]= Cloître du Monastère de S. Salvador à Oña",
         meta_data=expect_meta_data,
+        source=europeana.PROVIDER
     )
     assert total_images == 100
 
@@ -267,3 +268,31 @@ def test_get_description_without_description():
     expect_description = ""
 
     assert europeana._get_description(image_data) == expect_description
+
+
+def test_process_image_data_with_sub_provider():
+    image_data = _get_resource_json('image_data_sub_provider_example.json')
+    with patch.object(
+            europeana.image_store,
+            'add_item',
+            return_value=100
+    ) as mock_add_item:
+        total_images = europeana._process_image_data(image_data)
+
+    expect_meta_data = {
+        'country': ["United Kingdom"],
+        'dataProvider': ["Wellcome Collection"],
+        'description': "Lettering: Greenwich Hospital."
+    }
+
+    mock_add_item.assert_called_once_with(
+        foreign_landing_url="https://wellcomecollection.org/works/zzwnbyhb",
+        image_url="https://iiif.wellcomecollection.org/image/V0013398.jpg/full/512,/0/default.jpg",
+        license_url="http://creativecommons.org/licenses/by/4.0/",
+        thumbnail_url="https://api.europeana.eu/thumbnail/v2/url.json?uri=https%3A%2F%2Fiiif.wellcomecollection.org%2Fimage%2FV0013398.jpg%2Ffull%2F500%2C%2F0%2Fdefault.jpg&type=IMAGE",
+        foreign_identifier="/9200579/zzwnbyhb",
+        title="Royal Naval Hospital, Greenwich, with ships and rowing boats in the foreground. Engraving.",
+        meta_data=expect_meta_data,
+        source='wellcome_collection'
+    )
+    assert total_images == 100

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/europeana/image_data_sub_provider_example.json
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/europeana/image_data_sub_provider_example.json
@@ -1,0 +1,70 @@
+{
+   "completeness": 8,
+   "country": [
+      "United Kingdom"
+   ],
+   "dataProvider": [
+      "Wellcome Collection"
+   ],
+   "dcDescription": [
+      "Lettering: Greenwich Hospital."
+   ],
+   "dcDescriptionLangAware": {
+      "en": [
+         "Lettering: Greenwich Hospital."
+      ]
+   },
+   "dcTitleLangAware": {
+      "def": [
+         "Royal Naval Hospital, Greenwich, with ships and rowing boats in the foreground. Engraving."
+      ]
+   },
+   "dcTypeLangAware": {
+      "en": [
+         "Engravings"
+      ]
+   },
+   "edmDatasetName": [
+      "9200579_Ag_UK_WellcomeCollection_IIIF"
+   ],
+   "edmIsShownAt": [
+      "https://wellcomecollection.org/works/zzwnbyhb"
+   ],
+   "edmIsShownBy": [
+      "https://iiif.wellcomecollection.org/image/V0013398.jpg/full/512,/0/default.jpg"
+   ],
+   "edmPreview": [
+      "https://api.europeana.eu/thumbnail/v2/url.json?uri=https%3A%2F%2Fiiif.wellcomecollection.org%2Fimage%2FV0013398.jpg%2Ffull%2F500%2C%2F0%2Fdefault.jpg&type=IMAGE"
+   ],
+   "europeanaCollectionName": [
+      "9200579_Ag_UK_WellcomeCollection_IIIF"
+   ],
+   "europeanaCompleteness": 8,
+   "guid": "https://www.europeana.eu/item/9200579/zzwnbyhb?utm_source=api&utm_medium=api&utm_campaign=EoKgCesLr",
+   "id": "/9200579/zzwnbyhb",
+   "index": 0,
+   "language": [
+      "en"
+   ],
+   "link": "https://api.europeana.eu/api/v2/record/9200579/zzwnbyhb.json?wskey=EoKgCesLr",
+   "previewNoDistribute": false,
+   "provider": [
+      "Wellcome Collection"
+   ],
+   "rights": [
+      "http://creativecommons.org/licenses/by/4.0/"
+   ],
+   "score": 6.580116,
+   "timestamp": 1563330662398,
+   "timestamp_created": "2019-06-09T11:48:32.594Z",
+   "timestamp_created_epoch": 1560080912594,
+   "timestamp_update": "2019-06-09T11:48:32.594Z",
+   "timestamp_update_epoch": 1560080912594,
+   "title": [
+      "Royal Naval Hospital, Greenwich, with ships and rowing boats in the foreground. Engraving."
+   ],
+   "type": "IMAGE",
+   "ugc": [
+      false
+   ]
+}

--- a/src/cc_catalog_airflow/dags/test_sub_provider_update_workflow.py
+++ b/src/cc_catalog_airflow/dags/test_sub_provider_update_workflow.py
@@ -12,3 +12,12 @@ def test_flickr_dag_loads_with_no_errors(tmpdir):
         FILE_DIR, 'flickr_sub_provider_update_workflow.py'))
     assert len(dag_bag.import_errors) == 0
     assert len(dag_bag.dags) == 1
+
+
+def test_europeana_dag_loads_with_no_errors(tmpdir):
+    tmp_directory = str(tmpdir)
+    dag_bag = DagBag(dag_folder=tmp_directory, include_examples=False)
+    dag_bag.process_file(os.path.join(
+        FILE_DIR, 'europeana_sub_provider_update_workflow.py'))
+    assert len(dag_bag.import_errors) == 0
+    assert len(dag_bag.dags) == 1

--- a/src/cc_catalog_airflow/dags/util/loader/operators.py
+++ b/src/cc_catalog_airflow/dags/util/loader/operators.py
@@ -180,3 +180,15 @@ def get_flickr_sub_provider_update_operator(
         op_args=[postgres_conn_id],
         dag=dag
     )
+
+
+def get_europeana_sub_provider_update_operator(
+        dag,
+        postgres_conn_id,
+):
+    return PythonOperator(
+        task_id='update_europeana_sub_providers',
+        python_callable=sql.update_europeana_sub_providers,
+        op_args=[postgres_conn_id],
+        dag=dag
+    )

--- a/src/cc_catalog_airflow/dags/util/loader/provider_details.py
+++ b/src/cc_catalog_airflow/dags/util/loader/provider_details.py
@@ -1,8 +1,8 @@
 """
 This file holds the default provider names for each provider API and a
 dictionary of related sub providers. The key of the dictionary reflects
-the sub provider name and the corresponding item is a set of values from the
-API response which helps to identify the sub provider.
+the sub provider name and the corresponding item is a value (or set of values)
+from the API response which helps to identify the sub provider.
 
 Apart from that, this file stores other provider related information which
 might be useful for retrieving sub-providers at the database level and the
@@ -30,3 +30,10 @@ FLICKR_SUB_PROVIDERS = {
 }
 
 FLICKR_PHOTO_URL_BASE = 'https://www.flickr.com/photos/'
+
+# Europeana parameters
+EUROPEANA_DEFAULT_PROVIDER = 'europeana'
+
+EUROPEANA_SUB_PROVIDERS = {
+    'wellcome_collection': "Wellcome Collection"
+}

--- a/src/cc_catalog_airflow/dags/util/loader/sql.py
+++ b/src/cc_catalog_airflow/dags/util/loader/sql.py
@@ -293,9 +293,9 @@ def _delete_malformed_row_in_file(tsv_file_name, line_number):
                 write_obj.write(line)
 
 
-def _create_temp_sub_prov_table(
+def _create_temp_flickr_sub_prov_table(
         postgres_conn_id,
-        temp_table='temp_sub_prov_table'
+        temp_table='temp_flickr_sub_prov_table'
 ):
     """
     Drop the temporary table if it already exists
@@ -311,7 +311,7 @@ def _create_temp_sub_prov_table(
             f'''
             CREATE TABLE public.{temp_table} (
               {col.CREATOR_URL} character varying(2000),
-              {col.PROVIDER} character varying(80)
+              sub_provider character varying(80)
             );
             '''
         )
@@ -332,7 +332,7 @@ def _create_temp_sub_prov_table(
                     f'''
                     INSERT INTO public.{temp_table} (
                       {col.CREATOR_URL},
-                      {col.PROVIDER}
+                      sub_provider
                     )
                     VALUES (
                       '{creator_url}',
@@ -351,13 +351,13 @@ def update_flickr_sub_providers(
   default_provider=prov.FLICKR_DEFAULT_PROVIDER,
 ):
     postgres = PostgresHook(postgres_conn_id=postgres_conn_id)
-    temp_table = _create_temp_sub_prov_table(postgres_conn_id)
+    temp_table = _create_temp_flickr_sub_prov_table(postgres_conn_id)
 
     select_query = dedent(
         f'''
         SELECT
         {col.FOREIGN_ID} AS foreign_id,
-        public.{temp_table}.{col.PROVIDER} AS sub_provider
+        public.{temp_table}.sub_provider AS sub_provider
         FROM {image_table}
         INNER JOIN public.{temp_table}
         ON

--- a/src/cc_catalog_airflow/dags/util/loader/sql.py
+++ b/src/cc_catalog_airflow/dags/util/loader/sql.py
@@ -423,7 +423,7 @@ def update_europeana_sub_providers(
         source = next((s for s in sub_providers if sub_providers[s] in
                        data_providers), None)
         if source is not None:
-            filtered_records.append(row + [source])
+            filtered_records.append(list(row) + [source])
 
     for row in filtered_records:
         foreign_id = row[0]

--- a/src/cc_catalog_airflow/dags/util/loader/sql.py
+++ b/src/cc_catalog_airflow/dags/util/loader/sql.py
@@ -420,8 +420,15 @@ def update_europeana_sub_providers(
     filtered_records = []
     for row in selected_records:
         data_providers = ast.literal_eval(row[1])
-        source = next((s for s in sub_providers if sub_providers[s] in
-                       data_providers), None)
+
+        eligible_sub_providers = {s for s in sub_providers if sub_providers[s]
+                                  in data_providers}
+        if len(eligible_sub_providers) > 1:
+            raise Exception(f"More than one sub-provider identified for the "
+                            f"image with foreign ID {row[0]}")
+        source = eligible_sub_providers.pop() if \
+            len(eligible_sub_providers) == 1 else None
+
         if source is not None:
             filtered_records.append(list(row) + [source])
 

--- a/src/cc_catalog_airflow/dags/util/loader/sql.py
+++ b/src/cc_catalog_airflow/dags/util/loader/sql.py
@@ -500,3 +500,8 @@ def update_europeana_sub_providers(
                 '''
             )
         )
+
+    """
+    Drop the temporary table
+    """
+    postgres.run(f'DROP TABLE public.{temp_table};')


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #441 by @ChariniNana, Related to #392 

## Description
This addresses the requirement of retrieving sub providers within Europeana. For the time being, it only considers the 'Wellcome Collection' sub provider. The list of sub-providers considered may be expanded in the future. There are two aspects to this requirement which are as follows:

Retrieve sub-providers at the API level, as and when pulling data from the Europeana API.
Update the existing Europeana related information present in the database to reflect the sub-provider information

## Technical details
The content of the 'data provider' field of the Europeana API response helps to identify the sub providers uniquely. We maintain a mapping of the sub provider name to the 'data provider' value (which is a 1 to 1 mapping) to help with the sub provider retrieval. The 'data provider' value is stored as meta data in the image store.

The content of the 'data provider' field in the API response is a list of values. We expect this list to contain only one sub provider of interest. If in case it contains more than one sub provider value, we throw an error and terminate the program execution.

1. At the API script level, when an image is processed, we check whether the 'data provider' has a corresponding sub provider in the mapping, and set the source field in the Image Store to the relevant sub provider. Otherwise, the default sub provider 'europeana' is used.
2. At the DB level, we initially execute a select query to retrieve the foreign identifier and the 'data provider' values for all images from Europeana. Next, we process the output row by row, and if the 'data provider' value reflects a sub provider of interest, we update the corresponding row's _source_ value in the DB, to reflect the sub provider.

## Tests

1. API script level sub provider retrieval: The function `test_process_image_data_with_sub_provider` within `test_europeana` test suite checks whether the source is properly set when a sub provider from our mapping is encountered.
2. DB level sub provider update: The function `test_update_europeana_sub_providers` within `test_sql` checks the successful updating of the image table.
3. Test for the workflow created for DB sub-provider update is: `test_europeana_dag_loads_with_no_errors` within the `test_sub_provider_update_workflow` test suite.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ]  ~~I added or updated documentation (if applicable).~~
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
