### PR TITLE
use image name from URL for foreign_id instead of generated index

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/metropolitan_museum_of_art.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/metropolitan_museum_of_art.py
@@ -91,7 +91,7 @@ def _get_data_for_image(object_id):
     object_json = _get_and_validate_object_json(object_id)
     if not object_json:
         logger.warning(
-            f'Could not retrieve object_json for object_id:  {object_id}'
+            f'Could not retrieve object_json for object_id: {object_id}'
         )
         return
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_metropolitan_museum_of_art.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_metropolitan_museum_of_art.py
@@ -8,12 +8,11 @@ import metropolitan_museum_of_art as mma
 
 RESOURCES = os.path.join(
     os.path.abspath(os.path.dirname(__file__)),
-    'tests/resources/metropolitan_museum_of_art'
+    "tests/resources/metropolitan_museum_of_art",
 )
 
 logging.basicConfig(
-    format='%(asctime)s - %(name)s - %(levelname)s:  %(message)s',
-    level=logging.INFO
+    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s", level=logging.INFO
 )
 logger = logging.getLogger(__name__)
 
@@ -21,33 +20,22 @@ logger = logging.getLogger(__name__)
 def test_get_object_ids():
     r = requests.Response()
     r.status_code = 200
-    r.json = MagicMock(return_value={
-        'total': 4,
-        'objectIDs': [153, 1578, 465, 546]
-        })
-    with patch.object(
-        mma.delayed_requester,
-        'get',
-        return_value=r
-    ):
-        total_objects = mma._get_object_ids('')
+    r.json = MagicMock(return_value={"total": 4, "objectIDs": [153, 1578, 465, 546]})
+    with patch.object(mma.delayed_requester, "get", return_value=r):
+        total_objects = mma._get_object_ids("")
     assert total_objects[0] == 4
     assert total_objects[1] == [153, 1578, 465, 546]
 
 
 def test_get_response_json():
-    expect_json = {'it': 'works'}
-    endpoint = 'https://abc.com'
-    query_params = {'a': 'b'}
+    expect_json = {"it": "works"}
+    endpoint = "https://abc.com"
+    query_params = {"a": "b"}
     retries = 2
     with patch.object(
-            mma.delayed_requester,
-            'get_response_json',
-            return_value=expect_json
+        mma.delayed_requester, "get_response_json", return_value=expect_json
     ) as mock_get_response_json:
-        r_json = mma._get_response_json(
-            query_params, endpoint, retries=retries
-        )
+        r_json = mma._get_response_json(query_params, endpoint, retries=retries)
 
     assert r_json == expect_json
     mock_get_response_json.assert_called_once_with(
@@ -57,45 +45,33 @@ def test_get_response_json():
 
 def test_create_meta_data():
     exact_response = {
-        'accessionNumber': '36.100.45',
-        'classification': 'Paintings',
-        'creditLine': (
-            'The Howard Mansfield Collection, Purchase, Rogers Fund, 1936'
-            ),
-        'culture': 'Japan',
-        'objectDate': 'late 17th century',
-        'medium': 'Hanging scroll; ink and color on silk',
+        "accessionNumber": "36.100.45",
+        "classification": "Paintings",
+        "creditLine": ("The Howard Mansfield Collection, Purchase, Rogers Fund, 1936"),
+        "culture": "Japan",
+        "objectDate": "late 17th century",
+        "medium": "Hanging scroll; ink and color on silk",
     }
     exact_meta_data = {
-        'accession_number': '36.100.45',
-        'classification': 'Paintings',
-        'credit_line': (
-            'The Howard Mansfield Collection, Purchase, Rogers Fund, 1936'
-            ),
-        'culture': 'Japan',
-        'date': 'late 17th century',
-        'medium': 'Hanging scroll; ink and color on silk',
+        "accession_number": "36.100.45",
+        "classification": "Paintings",
+        "credit_line": ("The Howard Mansfield Collection, Purchase, Rogers Fund, 1936"),
+        "culture": "Japan",
+        "date": "late 17th century",
+        "medium": "Hanging scroll; ink and color on silk",
     }
     r = requests.Response()
     r.status_code = 200
     r.json = MagicMock(return_value=exact_response)
-    with patch.object(
-        mma.delayed_requester,
-        'get',
-        return_value=r
-    ):
-        response = mma._get_response_json(None, '', retries=2)
+    with patch.object(mma.delayed_requester, "get", return_value=r):
+        response = mma._get_response_json(None, "", retries=2)
         meta_data = mma._create_meta_data(response)
 
     assert exact_meta_data == meta_data
 
 
 def test_get_data_for_image_with_none_response():
-    with patch.object(
-            mma.delayed_requester,
-            'get',
-            return_value=None
-    ) as mock_get:
+    with patch.object(mma.delayed_requester, "get", return_value=None) as mock_get:
         with pytest.raises(Exception):
             assert mma._get_data_for_image(10)
 
@@ -106,11 +82,7 @@ def test_get_data_for_image_with_non_ok():
     r = requests.Response()
     r.status_code = 504
     r.json = MagicMock(return_value={})
-    with patch.object(
-            mma.delayed_requester,
-            'get',
-            return_value=r
-    ) as mock_get:
+    with patch.object(mma.delayed_requester, "get", return_value=r) as mock_get:
         with pytest.raises(Exception):
             assert mma._get_data_for_image(10)
 
@@ -118,75 +90,59 @@ def test_get_data_for_image_with_non_ok():
 
 
 def test_get_data_for_image_returns_response_json_when_all_ok(monkeypatch):
-    with open(
-        os.path.join(RESOURCES, 'sample_response_without_additional.json')
-    ) as f:
+    with open(os.path.join(RESOURCES, "sample_response_without_additional.json")) as f:
         actual_response_json = json.load(f)
 
     def mock_get_response_json(query_params, retries=0):
         return actual_response_json
 
-    monkeypatch.setattr(mma, '_get_response_json', mock_get_response_json)
-    with open(
-        os.path.join(RESOURCES, 'sample_additional_image_data.json')
-    ) as f:
+    monkeypatch.setattr(mma, "_get_response_json", mock_get_response_json)
+    with open(os.path.join(RESOURCES, "sample_additional_image_data.json")) as f:
         image_data = json.load(f)
 
     r = requests.Response()
     r.status_code = 200
     r.json = MagicMock(return_value=image_data)
-    with patch.object(
-        mma.image_store,
-        'add_item',
-        return_value=image_data
-    ) as mock_add:
+    with patch.object(mma.image_store, "add_item", return_value=image_data) as mock_add:
         mma._get_data_for_image(45733)
 
     mock_add.assert_called_with(
-        creator='',
-        foreign_identifier='45733-79_2_414b_S1_sf',
-        foreign_landing_url='https://www.metmuseum.org/art/collection/search/47533',
-        image_url='https://images.metmuseum.org/CRDImages/as/original/79_2_414b_S1_sf.jpg',
-        license_='cc0',
-        license_version='1.0',
+        creator="",
+        foreign_identifier="45733-79_2_414b_S1_sf",
+        foreign_landing_url="https://www.metmuseum.org/art/collection/search/47533",
+        image_url="https://images.metmuseum.org/CRDImages/as/original/79_2_414b_S1_sf.jpg",
+        license_="cc0",
+        license_version="1.0",
         meta_data={
-            'accession_number': '79.2.414b',
-            'classification': 'Ceramics',
-            'culture': 'China',
-            'date': '',
-            'medium': 'Porcelain painted in underglaze blue',
-            'credit_line': 'Purchase by subscription, 1879'
+            "accession_number": "79.2.414b",
+            "classification": "Ceramics",
+            "culture": "China",
+            "date": "",
+            "medium": "Porcelain painted in underglaze blue",
+            "credit_line": "Purchase by subscription, 1879",
         },
-        thumbnail_url='https://images.metmuseum.org/CRDImages/as/web-large/79_2_414b_S1_sf.jpg',
-        title='Cover'
+        thumbnail_url="https://images.metmuseum.org/CRDImages/as/web-large/79_2_414b_S1_sf.jpg",
+        title="Cover",
     )
 
     assert mock_add.call_count == 1
 
 
-def test_get_data_for_image_returns_response_json_with_additional_images(
-    monkeypatch
-):
-    with open(os.path.join(RESOURCES, 'sample_response.json')) as f:
+def test_get_data_for_image_returns_response_json_with_additional_images(monkeypatch):
+    with open(os.path.join(RESOURCES, "sample_response.json")) as f:
         actual_response_json = json.load(f)
 
     def mock_get_response_json(query_params, retries=0):
         return actual_response_json
 
-    monkeypatch.setattr(mma, '_get_response_json', mock_get_response_json)
-    with open(
-        os.path.join(RESOURCES, 'sample_additional_image_data.json')
-    ) as f:
+    monkeypatch.setattr(mma, "_get_response_json", mock_get_response_json)
+    with open(os.path.join(RESOURCES, "sample_additional_image_data.json")) as f:
         image_data = json.load(f)
 
     r = requests.Response()
     r.status_code = 200
     r.json = MagicMock(return_value=image_data)
-    with patch.object(
-        mma.image_store,
-        'add_item',
-        return_value=image_data
-    ) as mock_add:
+    with patch.object(mma.image_store, "add_item", return_value=image_data) as mock_add:
         mma._get_data_for_image(45734)
 
     mock_add.assert_called_with(
@@ -204,10 +160,10 @@ def test_get_data_for_image_returns_response_json_with_additional_images(
             "medium": "Hanging scroll; ink and color on silk",
             "credit_line": (
                 "The Howard Mansfield Collection, Purchase, Rogers Fund, 1936"
-                )
-            },
+            ),
+        },
         thumbnail_url=None,
-        title="Quail and Millet"
+        title="Quail and Millet",
     )
 
     assert mock_add.call_count == 3


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #416  by @mathemancer 

## Description
<!-- Concisely describe what the pull request does. -->
This fixes #416 by changing from appending on-the-fly generated indices to using a portion of the image URL which should be unique to identify images within a given object.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Tests have been added and modified to cover the new behavior.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] ~I added or updated documentation (if applicable).~
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
