### PR TITLE
Add total_images property to ImageStore

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/common/storage/image.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/common/storage/image.py
@@ -254,6 +254,12 @@ class ImageStore:
         output_path = os.path.join(output_dir, output_file)
         logger.info('Output path: {}'.format(output_path))
         return output_path
+    
+    def _get_total_images(self):
+        return self._total_images
+    
+    """Get total images for directly using in scripts."""
+    total_images = property(_get_total_images)
 
     def _get_image(
             self,

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/common/storage/image.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/common/storage/image.py
@@ -254,10 +254,10 @@ class ImageStore:
         output_path = os.path.join(output_dir, output_file)
         logger.info('Output path: {}'.format(output_path))
         return output_path
-    
+
     def _get_total_images(self):
         return self._total_images
-    
+
     """Get total images for directly using in scripts."""
     total_images = property(_get_total_images)
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/common/storage/test_image.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/common/storage/test_image.py
@@ -125,6 +125,26 @@ def test_ImageStore_commit_writes_nothing_if_no_lines_in_buffer():
     image_store.commit()
 
 
+def test_ImageStore_produces_correct_total_images(setup_env):
+    image_store = image.ImageStore(provider='testing_provider')
+    image_store.add_item(
+        foreign_landing_url='https://images.org/image01',
+        image_url='https://images.org/image01.jpg',
+        license_url='https://creativecommons.org/licenses/cc0/1.0/'
+    )
+    image_store.add_item(
+        foreign_landing_url='https://images.org/image02',
+        image_url='https://images.org/image02.jpg',
+        license_url='https://creativecommons.org/licenses/cc0/1.0/'
+    )
+    image_store.add_item(
+        foreign_landing_url='https://images.org/image03',
+        image_url='https://images.org/image03.jpg',
+        license_url='https://creativecommons.org/licenses/cc0/1.0/'
+    )
+    assert image_store.total_images == 3
+
+
 def test_ImageStore_get_image_places_given_args(
         monkeypatch,
         setup_env


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #403  by @mathemancer 

## Description
The `total_images` property gets the protected value from `ImageStore._total_images` and can be used directly for logging purposes in provider API scripts.

## Technical Details
The value can be used as:
```py
image_store = ImageStore(provider="test_provider")  # creating object
total = image_store.total_images  # using the total_images property
```

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
Test written for the same in `src/cc_catalog_airflow/dags/provider_api_scripts/common/storage/test_image.py`.
Also checked by using the value in one of the scripts and logging it.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] ~I added or updated documentation (if applicable).~
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
