### PR TITLE
Add an index to temporary popularity table identifier

### DIFF
--- a/src/cc_catalog_airflow/dags/util/popularity/sql.py
+++ b/src/cc_catalog_airflow/dags/util/popularity/sql.py
@@ -15,6 +15,7 @@ def upload_normalized_popularity(
         f"CREATE TEMP TABLE temp_popularity "
         f"  (identifier uuid, normalized_popularity text); "
         f"COPY temp_popularity FROM STDIN WITH CSV HEADER DELIMITER E'\t'; "
+        f"CREATE INDEX ident_idx ON temp_popularity (identifier);"
         f"UPDATE {image_table} SET meta_data = jsonb_set("
         f"  meta_data, "
         f"  '{{normalized_popularity}}',"


### PR DESCRIPTION
The popularity job never finishes uploading data back into the database. It's likely that this is because there is no index on the temporary popularity table's identifier key, which is used to match the old records.