### PR TITLE
Configure WMC ingestion DAG for smaller requests, greater parallelism

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -29,7 +29,7 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-LIMIT = 500
+LIMIT = 250
 # The 10000 is a bit arbitrary, but needs to be larger than the mean
 # number of uses per file (globally) in the response_json, or we will
 # fail without a continuation token.  The largest example seen so far

--- a/src/cc_catalog_airflow/dags/wikimedia_ingestion_workflow.py
+++ b/src/cc_catalog_airflow/dags/wikimedia_ingestion_workflow.py
@@ -45,6 +45,6 @@ globals()[DAG_ID] = create_day_partitioned_ingestion_dag(
     wikimedia_commons.main,
     reingestion_days,
     start_date=START_DATE,
-    concurrency=4,
+    concurrency=6,
     ingestion_task_timeout=INGESTION_TASK_TIMEOUT
 )

--- a/src/cc_catalog_airflow/dags/wikimedia_ingestion_workflow.py
+++ b/src/cc_catalog_airflow/dags/wikimedia_ingestion_workflow.py
@@ -45,6 +45,6 @@ globals()[DAG_ID] = create_day_partitioned_ingestion_dag(
     wikimedia_commons.main,
     reingestion_days,
     start_date=START_DATE,
-    concurrency=6,
+    concurrency=8,
     ingestion_task_timeout=INGESTION_TASK_TIMEOUT
 )


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #450  by @mathemancer

## Description
<!-- Concisely describe what the pull request does. -->
This PR reconfigures the Apache Airflow DAG that controls Wikimedia Commons ingestion to request fewer objects per request, but make more requests in parallel.  This avoids the bug by lowering the memory requirements on the server per request.  The increased parallelism is to try to make sure that the DAG can still run in the required amount of time.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] ~I added tests for the changes I made (if applicable).~
- [ ] ~I added or updated documentation (if applicable).~
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
