### PR TITLE
Check Wikimedia Commons objects for mediatype before storing

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
@@ -264,6 +264,23 @@ def test_process_image_data_handles_example_dict():
     )
 
 
+def test_process_image_data_throws_out_invalid_mediatype(monkeypatch):
+    image_data = {'mediatype': 'INVALID'}
+
+    def mock_check_mediatype(image_info):
+        return False
+
+    monkeypatch.setattr(wmc, '_check_mediatype', mock_check_mediatype)
+    with patch.object(
+            wmc.image_store,
+            'add_item',
+            return_value=1
+    ) as mock_add:
+        wmc._process_image_data(image_data)
+
+    mock_add.assert_not_called()
+
+
 def test_get_image_info_dict():
     with open(os.path.join(RESOURCES, 'image_data_example.json')) as f:
         image_data = json.load(f)
@@ -276,6 +293,28 @@ def test_get_image_info_dict():
     actual_image_info = wmc._get_image_info_dict(image_data)
 
     assert actual_image_info == expect_image_info
+
+
+def test_check_mediatype_with_valid_image_info():
+    with open(
+            os.path.join(RESOURCES, 'image_info_from_example_data.json')
+    ) as f:
+        image_info = json.load(f)
+
+    valid_mediatype = wmc._check_mediatype(image_info)
+    assert valid_mediatype is True
+
+
+def test_check_mediatype_with_invalid_mediatype_in_image_info():
+    with open(
+            os.path.join(RESOURCES, 'image_info_from_example_data.json')
+    ) as f:
+        image_info = json.load(f)
+
+    image_info.update(mediatype='INVALIDTYPE')
+
+    valid_mediatype = wmc._check_mediatype(image_info)
+    assert valid_mediatype is False
 
 
 def test_extract_creator_info_handles_plaintext():

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/wikimedia/image_data_example.json
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/wikimedia/image_data_example.json
@@ -1,104 +1,102 @@
 {
-  "pageid": 81754323,
-  "ns": 6,
-  "title": "File:20120925 PlozevetBretagne LoneTree DSC07971 PtrQs.jpg",
-  "imagerepository": "local",
-  "imageinfo": [
-    {
-      "user": "PtrQs",
-      "size": 11863148,
-      "width": 5514,
-      "height": 3102,
-      "thumburl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/20120925_PlozevetBretagne_LoneTree_DSC07971_PtrQs.jpg/300px-20120925_PlozevetBretagne_LoneTree_DSC07971_PtrQs.jpg",
-      "thumbwidth": 300,
-      "thumbheight": 169,
-      "url": "https://upload.wikimedia.org/wikipedia/commons/2/25/20120925_PlozevetBretagne_LoneTree_DSC07971_PtrQs.jpg",
-      "descriptionurl": "https://commons.wikimedia.org/wiki/File:20120925_PlozevetBretagne_LoneTree_DSC07971_PtrQs.jpg",
-      "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=81754323",
-      "extmetadata": {
-        "DateTime": {
-          "value": "2019-09-01 00:38:47",
-          "source": "mediawiki-metadata",
-          "hidden": ""
-        },
-        "ObjectName": {
-          "value": "20120925 PlozevetBretagne LoneTree DSC07971 PtrQs",
-          "source": "mediawiki-metadata",
-          "hidden": ""
-        },
-        "CommonsMetadataExtension": {
-          "value": 1.2,
-          "source": "extension",
-          "hidden": ""
-        },
-        "Categories": {
-          "value": "Coasts of Finistère|Photographs taken with Minolta AF Zoom 28-70mm F2.8 G|Plozévet|Self-published work|Taken with Sony DSLR-A900|Trees in Finistère",
-          "source": "commons-categories",
-          "hidden": ""
-        },
-        "Assessments": {
-          "value": "",
-          "source": "commons-categories",
-          "hidden": ""
-        },
-        "ImageDescription": {
-          "value": "SONY DSC",
-          "source": "commons-desc-page"
-        },
-        "DateTimeOriginal": {
-          "value": "2012-09-25 16:23:02",
-          "source": "commons-desc-page"
-        },
-        "Credit": {
-          "value": "<span class=\"int-own-work\" lang=\"en\">Own work</span>",
-          "source": "commons-desc-page",
-          "hidden": ""
-        },
-        "Artist": {
-          "value": "<a href=\"//commons.wikimedia.org/wiki/User:PtrQs\" title=\"User:PtrQs\">PtrQs</a>",
-          "source": "commons-desc-page"
-        },
-        "LicenseShortName": {
-          "value": "CC BY-SA 4.0",
-          "source": "commons-desc-page",
-          "hidden": ""
-        },
-        "UsageTerms": {
-          "value": "Creative Commons Attribution-Share Alike 4.0",
-          "source": "commons-desc-page",
-          "hidden": ""
-        },
-        "AttributionRequired": {
-          "value": "true",
-          "source": "commons-desc-page",
-          "hidden": ""
-        },
-        "Attribution": {
-          "value": "Photo by <a href=\"//commons.wikimedia.org/wiki/User:PtrQs\" title=\"User:PtrQs\">PtrQs</a>",
-          "source": "commons-desc-page",
-          "hidden": ""
-        },
-        "LicenseUrl": {
-          "value": "https://creativecommons.org/licenses/by-sa/4.0",
-          "source": "commons-desc-page",
-          "hidden": ""
-        },
-        "Copyrighted": {
-          "value": "True",
-          "source": "commons-desc-page",
-          "hidden": ""
-        },
-        "Restrictions": {
-          "value": "",
-          "source": "commons-desc-page",
-          "hidden": ""
-        },
-        "License": {
-          "value": "cc-by-sa-4.0",
-          "source": "commons-templates",
-          "hidden": ""
+    "pageid": 81754323,
+    "ns": 6,
+    "title": "File:20120925 PlozevetBretagne LoneTree DSC07971 PtrQs.jpg",
+    "imagerepository": "local",
+    "imageinfo": [
+        {
+            "user": "PtrQs",
+            "size": 11863148,
+            "width": 5514,
+            "height": 3102,
+            "url": "https://upload.wikimedia.org/wikipedia/commons/2/25/20120925_PlozevetBretagne_LoneTree_DSC07971_PtrQs.jpg",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:20120925_PlozevetBretagne_LoneTree_DSC07971_PtrQs.jpg",
+            "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=81754323",
+            "extmetadata": {
+                "DateTime": {
+                    "value": "2019-09-01 00:38:47",
+                    "source": "mediawiki-metadata",
+                    "hidden": ""
+                },
+                "ObjectName": {
+                    "value": "20120925 PlozevetBretagne LoneTree DSC07971 PtrQs",
+                    "source": "mediawiki-metadata",
+                    "hidden": ""
+                },
+                "CommonsMetadataExtension": {
+                    "value": 1.2,
+                    "source": "extension",
+                    "hidden": ""
+                },
+                "Categories": {
+                    "value": "Coasts of Ploz\u00e9vet|No QIC by usr:PtrQs|Photographs taken with Minolta AF Zoom 28-70mm F2.8 G|Self-published work|Taken with Sony DSLR-A900|Trees in Finist\u00e8re",
+                    "source": "commons-categories",
+                    "hidden": ""
+                },
+                "Assessments": {
+                    "value": "",
+                    "source": "commons-categories",
+                    "hidden": ""
+                },
+                "ImageDescription": {
+                    "value": "SONY DSC",
+                    "source": "commons-desc-page"
+                },
+                "DateTimeOriginal": {
+                    "value": "2012-09-25 16:23:02",
+                    "source": "commons-desc-page"
+                },
+                "Credit": {
+                    "value": "<span class=\"int-own-work\" lang=\"en\">Own work</span>",
+                    "source": "commons-desc-page",
+                    "hidden": ""
+                },
+                "Artist": {
+                    "value": "<a href=\"//commons.wikimedia.org/wiki/User:PtrQs\" title=\"User:PtrQs\">PtrQs</a>",
+                    "source": "commons-desc-page"
+                },
+                "LicenseShortName": {
+                    "value": "CC BY-SA 4.0",
+                    "source": "commons-desc-page",
+                    "hidden": ""
+                },
+                "UsageTerms": {
+                    "value": "Creative Commons Attribution-Share Alike 4.0",
+                    "source": "commons-desc-page",
+                    "hidden": ""
+                },
+                "AttributionRequired": {
+                    "value": "true",
+                    "source": "commons-desc-page",
+                    "hidden": ""
+                },
+                "Attribution": {
+                    "value": "Photo by <a href=\"//commons.wikimedia.org/wiki/User:PtrQs\" title=\"User:PtrQs\">PtrQs</a>",
+                    "source": "commons-desc-page",
+                    "hidden": ""
+                },
+                "LicenseUrl": {
+                    "value": "https://creativecommons.org/licenses/by-sa/4.0",
+                    "source": "commons-desc-page",
+                    "hidden": ""
+                },
+                "Copyrighted": {
+                    "value": "True",
+                    "source": "commons-desc-page",
+                    "hidden": ""
+                },
+                "Restrictions": {
+                    "value": "",
+                    "source": "commons-desc-page",
+                    "hidden": ""
+                },
+                "License": {
+                    "value": "cc-by-sa-4.0",
+                    "source": "commons-templates",
+                    "hidden": ""
+                }
+            },
+            "mediatype": "BITMAP"
         }
-      }
-    }
-  ]
+    ]
 }

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/wikimedia/image_info_from_example_data.json
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/tests/resources/wikimedia/image_info_from_example_data.json
@@ -1,96 +1,94 @@
 {
-  "user": "PtrQs",
-  "size": 11863148,
-  "width": 5514,
-  "height": 3102,
-  "thumburl": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/20120925_PlozevetBretagne_LoneTree_DSC07971_PtrQs.jpg/300px-20120925_PlozevetBretagne_LoneTree_DSC07971_PtrQs.jpg",
-  "thumbwidth": 300,
-  "thumbheight": 169,
-  "url": "https://upload.wikimedia.org/wikipedia/commons/2/25/20120925_PlozevetBretagne_LoneTree_DSC07971_PtrQs.jpg",
-  "descriptionurl": "https://commons.wikimedia.org/wiki/File:20120925_PlozevetBretagne_LoneTree_DSC07971_PtrQs.jpg",
-  "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=81754323",
-  "extmetadata": {
-    "DateTime": {
-      "value": "2019-09-01 00:38:47",
-      "source": "mediawiki-metadata",
-      "hidden": ""
+    "user": "PtrQs",
+    "size": 11863148,
+    "width": 5514,
+    "height": 3102,
+    "url": "https://upload.wikimedia.org/wikipedia/commons/2/25/20120925_PlozevetBretagne_LoneTree_DSC07971_PtrQs.jpg",
+    "descriptionurl": "https://commons.wikimedia.org/wiki/File:20120925_PlozevetBretagne_LoneTree_DSC07971_PtrQs.jpg",
+    "descriptionshorturl": "https://commons.wikimedia.org/w/index.php?curid=81754323",
+    "extmetadata": {
+        "DateTime": {
+            "value": "2019-09-01 00:38:47",
+            "source": "mediawiki-metadata",
+            "hidden": ""
+        },
+        "ObjectName": {
+            "value": "20120925 PlozevetBretagne LoneTree DSC07971 PtrQs",
+            "source": "mediawiki-metadata",
+            "hidden": ""
+        },
+        "CommonsMetadataExtension": {
+            "value": 1.2,
+            "source": "extension",
+            "hidden": ""
+        },
+        "Categories": {
+            "value": "Coasts of Ploz\u00e9vet|No QIC by usr:PtrQs|Photographs taken with Minolta AF Zoom 28-70mm F2.8 G|Self-published work|Taken with Sony DSLR-A900|Trees in Finist\u00e8re",
+            "source": "commons-categories",
+            "hidden": ""
+        },
+        "Assessments": {
+            "value": "",
+            "source": "commons-categories",
+            "hidden": ""
+        },
+        "ImageDescription": {
+            "value": "SONY DSC",
+            "source": "commons-desc-page"
+        },
+        "DateTimeOriginal": {
+            "value": "2012-09-25 16:23:02",
+            "source": "commons-desc-page"
+        },
+        "Credit": {
+            "value": "<span class=\"int-own-work\" lang=\"en\">Own work</span>",
+            "source": "commons-desc-page",
+            "hidden": ""
+        },
+        "Artist": {
+            "value": "<a href=\"//commons.wikimedia.org/wiki/User:PtrQs\" title=\"User:PtrQs\">PtrQs</a>",
+            "source": "commons-desc-page"
+        },
+        "LicenseShortName": {
+            "value": "CC BY-SA 4.0",
+            "source": "commons-desc-page",
+            "hidden": ""
+        },
+        "UsageTerms": {
+            "value": "Creative Commons Attribution-Share Alike 4.0",
+            "source": "commons-desc-page",
+            "hidden": ""
+        },
+        "AttributionRequired": {
+            "value": "true",
+            "source": "commons-desc-page",
+            "hidden": ""
+        },
+        "Attribution": {
+            "value": "Photo by <a href=\"//commons.wikimedia.org/wiki/User:PtrQs\" title=\"User:PtrQs\">PtrQs</a>",
+            "source": "commons-desc-page",
+            "hidden": ""
+        },
+        "LicenseUrl": {
+            "value": "https://creativecommons.org/licenses/by-sa/4.0",
+            "source": "commons-desc-page",
+            "hidden": ""
+        },
+        "Copyrighted": {
+            "value": "True",
+            "source": "commons-desc-page",
+            "hidden": ""
+        },
+        "Restrictions": {
+            "value": "",
+            "source": "commons-desc-page",
+            "hidden": ""
+        },
+        "License": {
+            "value": "cc-by-sa-4.0",
+            "source": "commons-templates",
+            "hidden": ""
+        }
     },
-    "ObjectName": {
-      "value": "20120925 PlozevetBretagne LoneTree DSC07971 PtrQs",
-      "source": "mediawiki-metadata",
-      "hidden": ""
-    },
-    "CommonsMetadataExtension": {
-      "value": 1.2,
-      "source": "extension",
-      "hidden": ""
-    },
-    "Categories": {
-      "value": "Coasts of Finistère|Photographs taken with Minolta AF Zoom 28-70mm F2.8 G|Plozévet|Self-published work|Taken with Sony DSLR-A900|Trees in Finistère",
-      "source": "commons-categories",
-      "hidden": ""
-    },
-    "Assessments": {
-      "value": "",
-      "source": "commons-categories",
-      "hidden": ""
-    },
-    "ImageDescription": {
-      "value": "SONY DSC",
-      "source": "commons-desc-page"
-    },
-    "DateTimeOriginal": {
-      "value": "2012-09-25 16:23:02",
-      "source": "commons-desc-page"
-    },
-    "Credit": {
-      "value": "<span class=\"int-own-work\" lang=\"en\">Own work</span>",
-      "source": "commons-desc-page",
-      "hidden": ""
-    },
-    "Artist": {
-      "value": "<a href=\"//commons.wikimedia.org/wiki/User:PtrQs\" title=\"User:PtrQs\">PtrQs</a>",
-      "source": "commons-desc-page"
-    },
-    "LicenseShortName": {
-      "value": "CC BY-SA 4.0",
-      "source": "commons-desc-page",
-      "hidden": ""
-    },
-    "UsageTerms": {
-      "value": "Creative Commons Attribution-Share Alike 4.0",
-      "source": "commons-desc-page",
-      "hidden": ""
-    },
-    "AttributionRequired": {
-      "value": "true",
-      "source": "commons-desc-page",
-      "hidden": ""
-    },
-    "Attribution": {
-      "value": "Photo by <a href=\"//commons.wikimedia.org/wiki/User:PtrQs\" title=\"User:PtrQs\">PtrQs</a>",
-      "source": "commons-desc-page",
-      "hidden": ""
-    },
-    "LicenseUrl": {
-      "value": "https://creativecommons.org/licenses/by-sa/4.0",
-      "source": "commons-desc-page",
-      "hidden": ""
-    },
-    "Copyrighted": {
-      "value": "True",
-      "source": "commons-desc-page",
-      "hidden": ""
-    },
-    "Restrictions": {
-      "value": "",
-      "source": "commons-desc-page",
-      "hidden": ""
-    },
-    "License": {
-      "value": "cc-by-sa-4.0",
-      "source": "commons-templates",
-      "hidden": ""
-    }
-  }
+    "mediatype": "BITMAP"
 }

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -22,11 +22,6 @@ import lxml.html as html
 import common.requester as requester
 import common.storage.image as image
 
-logging.basicConfig(
-    format='%(asctime)s - %(name)s - %(levelname)s:  %(message)s',
-    level=logging.INFO
-)
-
 logger = logging.getLogger(__name__)
 
 LIMIT = 500
@@ -360,6 +355,10 @@ def _cleanse_url(url_string):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        format='%(asctime)s - %(name)s - %(levelname)s:  %(message)s',
+        level=logging.INFO
+    )
     parser = argparse.ArgumentParser(
         description='Wikimedia Commons API Job',
         add_help=True,

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -53,12 +53,13 @@ DEFAULT_QUERY_PARAMS = {
     'gaidir': 'newer',
     'gailimit': LIMIT,
     'prop': 'imageinfo|globalusage',
-    'iiprop': 'url|user|dimensions|extmetadata',
+    'iiprop': 'url|user|dimensions|extmetadata|mediatype',
     'gulimit': LIMIT,
     'gunamespace': 0,
     'format': 'json',
 }
 PAGES_PATH = ['query', 'pages']
+IMAGE_MEDIATYPES = {'BITMAP'}
 
 delayed_requester = requester.DelayedRequester(DELAY)
 image_store = image.ImageStore(provider=PROVIDER)
@@ -230,6 +231,10 @@ def _process_image_data(image_data):
     foreign_id = image_data.get('pageid')
     logger.debug(f'Processing page ID: {foreign_id}')
     image_info = _get_image_info_dict(image_data)
+    valid_mediatype = _check_mediatype(image_info)
+    if not valid_mediatype:
+        return
+
     image_url = image_info.get('url')
     creator, creator_url = _extract_creator_info(image_info)
 
@@ -254,6 +259,19 @@ def _get_image_info_dict(image_data):
     else:
         image_info = {}
     return image_info
+
+
+def _check_mediatype(image_info, image_mediatypes=IMAGE_MEDIATYPES):
+    valid_mediatype = True
+    image_mediatype = image_info.get('mediatype')
+    if image_mediatype not in image_mediatypes:
+        logger.debug(
+            f'Incorrect mediatype: {image_mediatype} not in {image_mediatypes}'
+        )
+        valid_mediatype = False
+    else:
+        valid_mediatype = True
+    return valid_mediatype
 
 
 def _extract_date_info(image_info):

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -90,12 +90,14 @@ def main(date):
         logger.info(f'Continue Token: {continue_token}')
         image_pages = _get_image_pages(image_batch)
         if image_pages:
-            total_images = _process_image_pages(image_pages)
+            _process_image_pages(image_pages)
+            total_images = image_store.total_images
         logger.info(f'Total Images so far: {total_images}')
         if not continue_token:
             break
 
-    total_images = image_store.commit()
+    image_store.commit()
+    total_images = image_store.total_images
     logger.info(f'Total images: {total_images}')
     logger.info('Terminated!')
 
@@ -165,8 +167,7 @@ def _get_image_pages(image_batch):
 
 def _process_image_pages(image_pages):
     for i in image_pages.values():
-        total_images = _process_image_data(i)
-    return total_images
+        _process_image_data(i)
 
 
 def _build_query_params(
@@ -232,7 +233,7 @@ def _process_image_data(image_data):
     image_url = image_info.get('url')
     creator, creator_url = _extract_creator_info(image_info)
 
-    return image_store.add_item(
+    image_store.add_item(
         foreign_landing_url=image_info.get('descriptionshorturl'),
         image_url=image_url,
         license_url=_get_license_url(image_info),


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related To #438 by @aldenstpage 

## Description
<!-- Concisely describe what the pull request does. -->
The bulk of the problems described in #438 are due to the fact that we were not double-checking the media types of objects from Wikimedia Commons when retrieving their metadata.  This PR changes the request we make to get that information (the `mediatype`), and uses the info to decide whether or not to store metadata about that object.

There are also two minor clean up changes included:
1. Moved logging initialization so that it's avoided when `wikimedia_commons` is imported instead of run as a script.
2. Changed script to use new `total_images` property of the `ImageStore` class for easier understanding.

We cannot call #438 solved until we have:
1. Cleaned the DB after this PR is merged and deployed
2. Come up with a more robust, general way to try to keep non-image objects' metadata out of the image table.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
There are new tests covering the functionality.

Also, the reviewer may (should they so desire) use the README to set up the development environment, and run
```shell
python dags/provider_api_scripts/wikimedia_commons.py --date 2015-03-27
```
You shouldn't see any non-image objects in the local PostgreSQL after running that, but if you run the same from master, this will put metadata about a number of `.ogg` files (audio) in the `image` table of the local PostgreSQL DB.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] ~I added or updated documentation (if applicable).~
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
