### PR TITLE
Add the Women of Colour in Tech (WOCinTech) Flickr account as a sub-provider

### DIFF
--- a/src/cc_catalog_airflow/dags/util/loader/provider_details.py
+++ b/src/cc_catalog_airflow/dags/util/loader/provider_details.py
@@ -26,6 +26,9 @@ FLICKR_SUB_PROVIDERS = {
     },
     'spacex': {
         '130608600@N05'  # Official SpaceX Photos
+    },
+    'woc_tech': {
+        '136629440@N06'  # WOCinTech Chat
     }
 }
 


### PR DESCRIPTION
## Fixes
Fixes #443  by @annatuma 

## Description
This pull request adds WOCinTech as a sub-provider of Flickr, such that it has its own source on CC Search

## Technical details
Simply added the user ID of WOCinTech to the `provider_details.py` file such that the source of the corresponding images are set to the WOCinTech sub-provider value `woc_tech`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ]  ~I added tests for the changes I made (if applicable).~
- [ ]  ~I added or updated documentation (if applicable).~
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
