### PR TITLE
Collect 'Categories' metadata for images from Wikimedia Commons

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_wikimedia_commons.py
@@ -260,7 +260,8 @@ def test_process_image_data_handles_example_dict():
         title='File:20120925 PlozevetBretagne LoneTree DSC07971 PtrQs.jpg',
         meta_data={'description': 'SONY DSC', 'global_usage_count': 0,
                    'last_modified_at_source': '2019-09-01 00:38:47',
-                   'date_originally_created': '2012-09-25 16:23:02'}
+                   'date_originally_created': '2012-09-25 16:23:02',
+                   'categories': ['Coasts of Ploz\u00e9vet', 'No QIC by usr:PtrQs', 'Photographs taken with Minolta AF Zoom 28-70mm F2.8 G', 'Self-published work', 'Taken with Sony DSLR-A900', 'Trees in Finist\u00e8re']}
     )
 
 

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/wikimedia_commons.py
@@ -305,6 +305,18 @@ def _extract_creator_info(image_info):
     return (artist_text, artist_url)
 
 
+def _extract_category_info(image_info):
+    categories_string = (
+        image_info
+        .get('extmetadata', {})
+        .get('Categories', {})
+        .get('value', '')
+    )
+
+    categories_list = categories_string.split('|')
+    return categories_list
+
+
 def _get_license_url(image_info):
     return (
         image_info
@@ -321,6 +333,7 @@ def _create_meta_data_dict(image_data):
     image_info = _get_image_info_dict(image_data)
     date_originally_created, last_modified_at_source = _extract_date_info(
         image_info)
+    categories_list = _extract_category_info(image_info)
     description = (
         image_info
         .get('extmetadata', {})
@@ -335,6 +348,7 @@ def _create_meta_data_dict(image_data):
     meta_data['global_usage_count'] = global_usage_length
     meta_data['date_originally_created'] = date_originally_created
     meta_data['last_modified_at_source'] = last_modified_at_source
+    meta_data['categories'] = categories_list
     return meta_data
 
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #481 by @mathemancer 

## Description
<!-- Concisely describe what the pull request does. -->
This adds an `_extract_category_info()` function to get all the categories from `extmetadata`, and then process it and store it `meta_data` dict.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
I will add soon.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
