### PR TITLE
Cleaner workflow parallelism

### DIFF
--- a/src/cc_catalog_airflow/dags/cleaner_workflow.py
+++ b/src/cc_catalog_airflow/dags/cleaner_workflow.py
@@ -17,7 +17,7 @@ DAG_ID = "postgres_image_cleaner"
 DB_CONN_ID = os.getenv("OPENLEDGER_CONN_ID", "postgres_openledger_testing")
 PREFIX_LENGTH = 1
 DESIRED_PREFIX_LENGTH = 3
-CONCURRENCY = 16
+CONCURRENCY = 8
 
 
 def create_id_partitioned_cleaner_dag(

--- a/src/cc_catalog_airflow/dags/util/pg_cleaner.py
+++ b/src/cc_catalog_airflow/dags/util/pg_cleaner.py
@@ -63,10 +63,12 @@ class ImageStoreDict(dict):
         output_dir=OUTPUT_DIR_PATH,
         overwrite_dir=OVERWRITE_DIR,
     ):
+        output_path = os.path.join(output_dir, overwrite_dir)
+        os.makedirs(output_path, exist_ok=True)
         return image.ImageStore(
             provider=key[0],
             output_file=f"cleaned_{key[1]}.tsv",
-            output_dir=os.path.join(output_dir, overwrite_dir),
+            output_dir=output_path,
         )
 
 
@@ -172,7 +174,7 @@ def _clean_single_row(record, image_store_dict, prefix):
         image_url=dirty_row.image_url,
         thumbnail_url=dirty_row.thumbnail_url,
         license_url=tsv_cleaner.get_license_url(dirty_row.meta_data),
-        license_=dirty_row.license_,
+        license_=dirty_row.license_.lower(),
         license_version=dirty_row.license_version,
         foreign_identifier=dirty_row.foreign_identifier,
         width=dirty_row.width,
@@ -181,7 +183,7 @@ def _clean_single_row(record, image_store_dict, prefix):
         creator_url=dirty_row.creator_url,
         title=dirty_row.title,
         meta_data=dirty_row.meta_data,
-        raw_tags=dirty_row.tags,
+        raw_tags=[t for t in dirty_row.tags if t],
         watermarked=dirty_row.watermarked,
         source=dirty_row.source,
     )

--- a/src/cc_catalog_airflow/dags/util/pg_cleaner.py
+++ b/src/cc_catalog_airflow/dags/util/pg_cleaner.py
@@ -19,6 +19,7 @@ from util.loader.sql import IMAGE_TABLE_NAME
 
 logger = logging.getLogger(__name__)
 logging.getLogger(image.__name__).setLevel(logging.WARNING)
+logging.getLogger(image.columns.urls.__name__).setLevel(logging.WARNING)
 
 MAX_DIR_SIZE = 8 * 1024 ** 3
 OUTPUT_DIR = os.path.realpath(os.getenv("OUTPUT_DIR", "/tmp/"))

--- a/src/cc_catalog_airflow/dags/util/pg_cleaner.py
+++ b/src/cc_catalog_airflow/dags/util/pg_cleaner.py
@@ -6,6 +6,7 @@ class.
 from collections import namedtuple
 import logging
 import os
+from pathlib import Path
 from textwrap import dedent
 import time
 
@@ -109,6 +110,10 @@ def clean_prefix_loop(
         raise CleaningException()
 
 
+def _wait_for_space_and_time(total_time):
+    pass
+
+
 def clean_rows(postgres_conn_id, prefix):
     """
     This function runs all rows from the image table whose identifier
@@ -168,12 +173,14 @@ def _clean_single_row(record, image_store_dict, prefix):
     dirty_row = ImageTableRow(*record)
     image_store = image_store_dict[(dirty_row.provider, prefix)]
     total_images_before = image_store.total_images
+    license_lower = dirty_row.license_.lower() if dirty_row.license_ else None
+    tags_list = [t for t in dirty_row.tags if t] if dirty_row.tags else None
     image_store.add_item(
         foreign_landing_url=dirty_row.foreign_landing_url,
         image_url=dirty_row.image_url,
         thumbnail_url=dirty_row.thumbnail_url,
         license_url=tsv_cleaner.get_license_url(dirty_row.meta_data),
-        license_=dirty_row.license_.lower(),
+        license_=license_lower,
         license_version=dirty_row.license_version,
         foreign_identifier=dirty_row.foreign_identifier,
         width=dirty_row.width,
@@ -182,7 +189,7 @@ def _clean_single_row(record, image_store_dict, prefix):
         creator_url=dirty_row.creator_url,
         title=dirty_row.title,
         meta_data=dirty_row.meta_data,
-        raw_tags=[t for t in dirty_row.tags if t],
+        raw_tags=tags_list,
         watermarked=dirty_row.watermarked,
         source=dirty_row.source,
     )

--- a/src/cc_catalog_airflow/dags/util/test_pg_cleaner.py
+++ b/src/cc_catalog_airflow/dags/util/test_pg_cleaner.py
@@ -699,6 +699,113 @@ def test_clean_single_row_handles_uppercase_license_and_adds_row():
     mock_image_store.assert_has_calls(expected_calls)
 
 
+def test_clean_single_row_handles_missing_license_and_adds_row():
+    row = (
+        "000000ea-9a81-47dd-a83c-a2093ea4741b",
+        datetime.datetime(
+            2020,
+            10,
+            12,
+            18,
+            11,
+            57,
+            791507,
+            tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None),
+        ),
+        datetime.datetime(
+            2020,
+            10,
+            15,
+            8,
+            10,
+            42,
+            421899,
+            tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None),
+        ),
+        "provider_api",
+        "smithsonian",
+        "smithsonian_national_museum_of_natural_history",
+        "ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+        "https://n2t.net/ark:/65665/3f07eb37b-d022-4d44-90de-179a4aaf1c82",
+        "https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+        "https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c/90",
+        None,
+        None,
+        None,
+        None,
+        "1.0",
+        "Susan Gabriella Stokes",
+        None,
+        "Eriogonum latifolium Sm.",
+        {
+            "unit_code": "NMNHBOTANY",
+            "data_source": "NMNH - Botany Dept.",
+            "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "raw_license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        },
+        [
+            {"name": "1930s", "provider": "smithsonian"},
+            {"name": "Dicotyledonae", "provider": "smithsonian"},
+            {"name": "United States", "provider": "smithsonian"},
+            {"name": "California", "provider": "smithsonian"},
+            {"name": "North America", "provider": "smithsonian"},
+        ],
+        False,
+        datetime.datetime(
+            2020,
+            10,
+            15,
+            8,
+            10,
+            42,
+            421899,
+            tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None),
+        ),
+        False,
+    )
+    image_store_dict = pg_cleaner.ImageStoreDict()
+    expected_calls = [
+        call(
+            provider="smithsonian",
+            output_file="cleaned_000000.tsv",
+            output_dir=pg_cleaner.OUTPUT_PATH,
+        ),
+        call().add_item(
+            foreign_landing_url="https://n2t.net/ark:/65665/3f07eb37b-d022-4d44-90de-179a4aaf1c82",
+            image_url="https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+            thumbnail_url="https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c/90",
+            license_url="https://creativecommons.org/publicdomain/zero/1.0/",
+            license_=None,
+            license_version="1.0",
+            foreign_identifier="ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+            width=None,
+            height=None,
+            creator="Susan Gabriella Stokes",
+            creator_url=None,
+            title="Eriogonum latifolium Sm.",
+            meta_data={
+                "unit_code": "NMNHBOTANY",
+                "data_source": "NMNH - Botany Dept.",
+                "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "raw_license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+            },
+            raw_tags=[
+                {"name": "1930s", "provider": "smithsonian"},
+                {"name": "Dicotyledonae", "provider": "smithsonian"},
+                {"name": "United States", "provider": "smithsonian"},
+                {"name": "California", "provider": "smithsonian"},
+                {"name": "North America", "provider": "smithsonian"},
+            ],
+            watermarked=False,
+            source="smithsonian_national_museum_of_natural_history",
+        ),
+    ]
+    with patch.object(pg_cleaner.image, "ImageStore") as mock_image_store:
+        pg_cleaner._clean_single_row(row, image_store_dict, "000000")
+
+    mock_image_store.assert_has_calls(expected_calls)
+
+
 def test_clean_single_row_handles_defective_tags_and_adds_row():
     row = (
         "000000ea-9a81-47dd-a83c-a2093ea4741b",
@@ -799,6 +906,101 @@ def test_clean_single_row_handles_defective_tags_and_adds_row():
                 {"name": "California", "provider": "smithsonian"},
                 {"name": "North America", "provider": "smithsonian"},
             ],
+            watermarked=False,
+            source="smithsonian_national_museum_of_natural_history",
+        ),
+    ]
+    with patch.object(pg_cleaner.image, "ImageStore") as mock_image_store:
+        pg_cleaner._clean_single_row(row, image_store_dict, "000000")
+
+    mock_image_store.assert_has_calls(expected_calls)
+
+
+def test_clean_single_row_handles_missing_tags_and_adds_row():
+    row = (
+        "000000ea-9a81-47dd-a83c-a2093ea4741b",
+        datetime.datetime(
+            2020,
+            10,
+            12,
+            18,
+            11,
+            57,
+            791507,
+            tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None),
+        ),
+        datetime.datetime(
+            2020,
+            10,
+            15,
+            8,
+            10,
+            42,
+            421899,
+            tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None),
+        ),
+        "provider_api",
+        "smithsonian",
+        "smithsonian_national_museum_of_natural_history",
+        "ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+        "https://n2t.net/ark:/65665/3f07eb37b-d022-4d44-90de-179a4aaf1c82",
+        "https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+        "https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c/90",
+        None,
+        None,
+        None,
+        "cc0",
+        "1.0",
+        "Susan Gabriella Stokes",
+        None,
+        "Eriogonum latifolium Sm.",
+        {
+            "unit_code": "NMNHBOTANY",
+            "data_source": "NMNH - Botany Dept.",
+            "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "raw_license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        },
+        None,
+        False,
+        datetime.datetime(
+            2020,
+            10,
+            15,
+            8,
+            10,
+            42,
+            421899,
+            tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None),
+        ),
+        False,
+    )
+    image_store_dict = pg_cleaner.ImageStoreDict()
+    expected_calls = [
+        call(
+            provider="smithsonian",
+            output_file="cleaned_000000.tsv",
+            output_dir=pg_cleaner.OUTPUT_PATH,
+        ),
+        call().add_item(
+            foreign_landing_url="https://n2t.net/ark:/65665/3f07eb37b-d022-4d44-90de-179a4aaf1c82",
+            image_url="https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+            thumbnail_url="https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c/90",
+            license_url="https://creativecommons.org/publicdomain/zero/1.0/",
+            license_="cc0",
+            license_version="1.0",
+            foreign_identifier="ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+            width=None,
+            height=None,
+            creator="Susan Gabriella Stokes",
+            creator_url=None,
+            title="Eriogonum latifolium Sm.",
+            meta_data={
+                "unit_code": "NMNHBOTANY",
+                "data_source": "NMNH - Botany Dept.",
+                "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "raw_license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+            },
+            raw_tags=None,
             watermarked=False,
             source="smithsonian_national_museum_of_natural_history",
         ),

--- a/src/cc_catalog_airflow/dags/util/test_pg_cleaner.py
+++ b/src/cc_catalog_airflow/dags/util/test_pg_cleaner.py
@@ -554,10 +554,7 @@ def test_clean_single_row_inits_image_store_and_adds_row():
         call(
             provider="smithsonian",
             output_file="cleaned_000000.tsv",
-            output_dir=os.path.join(
-                pg_cleaner.OUTPUT_DIR_PATH,
-                pg_cleaner.OVERWRITE_DIR,
-            ),
+            output_dir=pg_cleaner.OUTPUT_PATH,
         ),
         call().add_item(
             foreign_landing_url="https://n2t.net/ark:/65665/3f07eb37b-d022-4d44-90de-179a4aaf1c82",
@@ -664,10 +661,7 @@ def test_clean_single_row_handles_uppercase_license_and_adds_row():
         call(
             provider="smithsonian",
             output_file="cleaned_000000.tsv",
-            output_dir=os.path.join(
-                pg_cleaner.OUTPUT_DIR_PATH,
-                pg_cleaner.OVERWRITE_DIR,
-            ),
+            output_dir=pg_cleaner.OUTPUT_PATH,
         ),
         call().add_item(
             foreign_landing_url="https://n2t.net/ark:/65665/3f07eb37b-d022-4d44-90de-179a4aaf1c82",
@@ -777,10 +771,7 @@ def test_clean_single_row_handles_defective_tags_and_adds_row():
         call(
             provider="smithsonian",
             output_file="cleaned_000000.tsv",
-            output_dir=os.path.join(
-                pg_cleaner.OUTPUT_DIR_PATH,
-                pg_cleaner.OVERWRITE_DIR,
-            ),
+            output_dir=pg_cleaner.OUTPUT_PATH,
         ),
         call().add_item(
             foreign_landing_url="https://n2t.net/ark:/65665/3f07eb37b-d022-4d44-90de-179a4aaf1c82",

--- a/src/cc_catalog_airflow/dags/util/test_pg_cleaner.py
+++ b/src/cc_catalog_airflow/dags/util/test_pg_cleaner.py
@@ -555,7 +555,231 @@ def test_clean_single_row_inits_image_store_and_adds_row():
             provider="smithsonian",
             output_file="cleaned_000000.tsv",
             output_dir=os.path.join(
-                pg_cleaner.OUTPUT_DIR_PATH, pg_cleaner.OVERWRITE_DIR,
+                pg_cleaner.OUTPUT_DIR_PATH,
+                pg_cleaner.OVERWRITE_DIR,
+            ),
+        ),
+        call().add_item(
+            foreign_landing_url="https://n2t.net/ark:/65665/3f07eb37b-d022-4d44-90de-179a4aaf1c82",
+            image_url="https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+            thumbnail_url="https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c/90",
+            license_url="https://creativecommons.org/publicdomain/zero/1.0/",
+            license_="cc0",
+            license_version="1.0",
+            foreign_identifier="ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+            width=None,
+            height=None,
+            creator="Susan Gabriella Stokes",
+            creator_url=None,
+            title="Eriogonum latifolium Sm.",
+            meta_data={
+                "unit_code": "NMNHBOTANY",
+                "data_source": "NMNH - Botany Dept.",
+                "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "raw_license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+            },
+            raw_tags=[
+                {"name": "1930s", "provider": "smithsonian"},
+                {"name": "Dicotyledonae", "provider": "smithsonian"},
+                {"name": "United States", "provider": "smithsonian"},
+                {"name": "California", "provider": "smithsonian"},
+                {"name": "North America", "provider": "smithsonian"},
+            ],
+            watermarked=False,
+            source="smithsonian_national_museum_of_natural_history",
+        ),
+    ]
+    with patch.object(pg_cleaner.image, "ImageStore") as mock_image_store:
+        pg_cleaner._clean_single_row(row, image_store_dict, "000000")
+
+    mock_image_store.assert_has_calls(expected_calls)
+
+
+def test_clean_single_row_handles_uppercase_license_and_adds_row():
+    row = (
+        "000000ea-9a81-47dd-a83c-a2093ea4741b",
+        datetime.datetime(
+            2020,
+            10,
+            12,
+            18,
+            11,
+            57,
+            791507,
+            tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None),
+        ),
+        datetime.datetime(
+            2020,
+            10,
+            15,
+            8,
+            10,
+            42,
+            421899,
+            tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None),
+        ),
+        "provider_api",
+        "smithsonian",
+        "smithsonian_national_museum_of_natural_history",
+        "ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+        "https://n2t.net/ark:/65665/3f07eb37b-d022-4d44-90de-179a4aaf1c82",
+        "https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+        "https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c/90",
+        None,
+        None,
+        None,
+        "CC0",
+        "1.0",
+        "Susan Gabriella Stokes",
+        None,
+        "Eriogonum latifolium Sm.",
+        {
+            "unit_code": "NMNHBOTANY",
+            "data_source": "NMNH - Botany Dept.",
+            "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "raw_license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        },
+        [
+            {"name": "1930s", "provider": "smithsonian"},
+            {"name": "Dicotyledonae", "provider": "smithsonian"},
+            {"name": "United States", "provider": "smithsonian"},
+            {"name": "California", "provider": "smithsonian"},
+            {"name": "North America", "provider": "smithsonian"},
+        ],
+        False,
+        datetime.datetime(
+            2020,
+            10,
+            15,
+            8,
+            10,
+            42,
+            421899,
+            tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None),
+        ),
+        False,
+    )
+    image_store_dict = pg_cleaner.ImageStoreDict()
+    expected_calls = [
+        call(
+            provider="smithsonian",
+            output_file="cleaned_000000.tsv",
+            output_dir=os.path.join(
+                pg_cleaner.OUTPUT_DIR_PATH,
+                pg_cleaner.OVERWRITE_DIR,
+            ),
+        ),
+        call().add_item(
+            foreign_landing_url="https://n2t.net/ark:/65665/3f07eb37b-d022-4d44-90de-179a4aaf1c82",
+            image_url="https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+            thumbnail_url="https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c/90",
+            license_url="https://creativecommons.org/publicdomain/zero/1.0/",
+            license_="cc0",
+            license_version="1.0",
+            foreign_identifier="ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+            width=None,
+            height=None,
+            creator="Susan Gabriella Stokes",
+            creator_url=None,
+            title="Eriogonum latifolium Sm.",
+            meta_data={
+                "unit_code": "NMNHBOTANY",
+                "data_source": "NMNH - Botany Dept.",
+                "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "raw_license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+            },
+            raw_tags=[
+                {"name": "1930s", "provider": "smithsonian"},
+                {"name": "Dicotyledonae", "provider": "smithsonian"},
+                {"name": "United States", "provider": "smithsonian"},
+                {"name": "California", "provider": "smithsonian"},
+                {"name": "North America", "provider": "smithsonian"},
+            ],
+            watermarked=False,
+            source="smithsonian_national_museum_of_natural_history",
+        ),
+    ]
+    with patch.object(pg_cleaner.image, "ImageStore") as mock_image_store:
+        pg_cleaner._clean_single_row(row, image_store_dict, "000000")
+
+    mock_image_store.assert_has_calls(expected_calls)
+
+
+def test_clean_single_row_handles_defective_tags_and_adds_row():
+    row = (
+        "000000ea-9a81-47dd-a83c-a2093ea4741b",
+        datetime.datetime(
+            2020,
+            10,
+            12,
+            18,
+            11,
+            57,
+            791507,
+            tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None),
+        ),
+        datetime.datetime(
+            2020,
+            10,
+            15,
+            8,
+            10,
+            42,
+            421899,
+            tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None),
+        ),
+        "provider_api",
+        "smithsonian",
+        "smithsonian_national_museum_of_natural_history",
+        "ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+        "https://n2t.net/ark:/65665/3f07eb37b-d022-4d44-90de-179a4aaf1c82",
+        "https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c",
+        "https://ids.si.edu/ids/deliveryService/id/ark:/65665/m3272d5bfa5716461fbf173e083887621c/90",
+        None,
+        None,
+        None,
+        "cc0",
+        "1.0",
+        "Susan Gabriella Stokes",
+        None,
+        "Eriogonum latifolium Sm.",
+        {
+            "unit_code": "NMNHBOTANY",
+            "data_source": "NMNH - Botany Dept.",
+            "license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "raw_license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        },
+        [
+            {},
+            "",
+            None,
+            {"name": "1930s", "provider": "smithsonian"},
+            {"name": "Dicotyledonae", "provider": "smithsonian"},
+            {"name": "United States", "provider": "smithsonian"},
+            {"name": "California", "provider": "smithsonian"},
+            {"name": "North America", "provider": "smithsonian"},
+        ],
+        False,
+        datetime.datetime(
+            2020,
+            10,
+            15,
+            8,
+            10,
+            42,
+            421899,
+            tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=0, name=None),
+        ),
+        False,
+    )
+    image_store_dict = pg_cleaner.ImageStoreDict()
+    expected_calls = [
+        call(
+            provider="smithsonian",
+            output_file="cleaned_000000.tsv",
+            output_dir=os.path.join(
+                pg_cleaner.OUTPUT_DIR_PATH,
+                pg_cleaner.OVERWRITE_DIR,
             ),
         ),
         call().add_item(

--- a/src/cc_catalog_airflow/dags/util/tsv_cleaner.py
+++ b/src/cc_catalog_airflow/dags/util/tsv_cleaner.py
@@ -80,4 +80,13 @@ def _get_json_from_string(json_str):
 
 
 def get_license_url(meta_data):
-    return meta_data.get("raw_license_url", meta_data.get("license_url", None))
+    try:
+        license_url = meta_data.get(
+            "raw_license_url", meta_data.get("license_url", None)
+        )
+    except Exception as e:
+        logger.debug(
+            f"Couldn't retrieve license URL from {meta_data}.  Error: {e}"
+        )
+        license_url = None
+    return license_url if license_url else None


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #522  by @mathemancer 

## Description
<!-- Concisely describe what the pull request does. -->

This modifies the cleaning logic to avoid failing to clean a row whenever it's missing tags or metadata (or these fields are defective).  Instead, the dag cleans the rest of the fields, writes the result, and continues.  This PR also turns the concurrency of the DAG down to 8, to avoid as many locking problems in the DB.  Finally, in the event the DAG fails to clean a particular row, it now logs that row's identifier into a file for further analysis.  It also turns the logging down for a couple of particularly noisy modules. 

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

There are tests covering the new functionality.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the *default* branch of the repository (`main` or `master`).
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] ~I added or updated documentation (if applicable).~
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
