### PR TITLE
Use execution date to choose data files 

### DIFF
--- a/src/cc_catalog_airflow/dags/commoncrawl_etl.py
+++ b/src/cc_catalog_airflow/dags/commoncrawl_etl.py
@@ -3,8 +3,6 @@ import logging
 import os
 
 from airflow import DAG
-from airflow.hooks.S3_hook import S3Hook
-from airflow.operators.python_operator import PythonOperator
 
 from util.etl import operators
 

--- a/src/cc_catalog_airflow/dags/util/etl/test_operators.py
+++ b/src/cc_catalog_airflow/dags/util/etl/test_operators.py
@@ -40,9 +40,9 @@ def test_load_file_to_s3_loads_file():
     )
 
 
-def test_get_job_flow_id_template():
+def test_get_task_return_value_template():
     expect_template_string = (
         "{{ task_instance.xcom_pull(task_ids='abc123', key='return_value') }}"
     )
-    actual_template_string = operators._get_job_flow_id_template("abc123")
-    assert actual_template_string == expect_template_string
+    actual_string = operators._get_task_return_value_template("abc123")
+    assert actual_string == expect_template_string

--- a/src/cc_catalog_airflow/local_s3/create_bucket.py
+++ b/src/cc_catalog_airflow/local_s3/create_bucket.py
@@ -6,27 +6,27 @@ import boto3
 from botocore.httpsession import EndpointConnectionError
 
 logging.basicConfig(
-    format='%(asctime)s - %(name)s - %(levelname)s:  %(message)s',
-    level=logging.INFO
+    format="%(asctime)s - %(name)s - %(levelname)s:  %(message)s",
+    level=logging.INFO,
 )
 
 logger = logging.getLogger(__file__)
 
 TRIES = 10
 S3 = boto3.resource(
-    service_name='s3',
-    region_name='us-east-1',
-    endpoint_url='http://localhost:5000',
-    aws_access_key_id='test_key',
-    aws_secret_access_key='test_secret',
+    service_name="s3",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:5000",
+    aws_access_key_id="test_key",
+    aws_secret_access_key="test_secret",
 )
-BUCKET_LIST = ['cccatalog-storage', 'commonsmapper-v2', 'commonsmapper']
+BUCKET_LIST = ["cccatalog-storage", "commonsmapper-v2", "commonsmapper"]
 
 
 def main():
     success = _create_local_s3_buckets()
     if not success:
-        logger.error('Could not create bucket in local S3')
+        logger.error("Could not create bucket in local S3")
         sys.exit(1)
     else:
         sys.exit(0)
@@ -44,21 +44,21 @@ def _create_local_s3_bucket(tries=TRIES, s3=S3, bucket_name=BUCKET_LIST[0]):
     for i in range(1, TRIES + 1):
         try:
             logger.info(
-                f'Attempting to create bucket {bucket_name}'
-                ' using local s3 connection'
+                f"Attempting to create bucket {bucket_name}"
+                " using local s3 connection"
             )
             s3.create_bucket(Bucket=bucket_name)
             success = True
             break
         except EndpointConnectionError as conn_e:
-            logger.info('S3 not yet available')
-            logger.debug(f'Error was:  {conn_e}')
-            logger.info(f'Waiting {i} seconds...')
+            logger.info("S3 not yet available")
+            logger.debug(f"Error was:  {conn_e}")
+            logger.info(f"Waiting {i} seconds...")
             # Back off with each loop to give the S3 container a chance to
             # start.
             time.sleep(i)
     return success
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/cc_catalog_airflow/local_s3/create_bucket.py
+++ b/src/cc_catalog_airflow/local_s3/create_bucket.py
@@ -20,11 +20,11 @@ S3 = boto3.resource(
     aws_access_key_id='test_key',
     aws_secret_access_key='test_secret',
 )
-BUCKET_NAME = 'cccatalog-storage'
+BUCKET_LIST = ['cccatalog-storage', 'commonsmapper-v2', 'commonsmapper']
 
 
 def main():
-    success = _create_local_s3_bucket()
+    success = _create_local_s3_buckets()
     if not success:
         logger.error('Could not create bucket in local S3')
         sys.exit(1)
@@ -32,7 +32,14 @@ def main():
         sys.exit(0)
 
 
-def _create_local_s3_bucket(tries=TRIES, s3=S3, bucket_name=BUCKET_NAME):
+def _create_local_s3_buckets(bucket_list=BUCKET_LIST):
+    success = True
+    for bucket in bucket_list:
+        success = min(success, _create_local_s3_bucket(bucket_name=bucket))
+    return success
+
+
+def _create_local_s3_bucket(tries=TRIES, s3=S3, bucket_name=BUCKET_LIST[0]):
     success = False
     for i in range(1, TRIES + 1):
         try:


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #531  by @mathemancer 

## Description
<!-- Concisely describe what the pull request does. -->

This modifies the Apache Airflow DAG `commoncrawl_etl_workflowschedule` (found in `src/cc_catalog_airflow/dags/commoncrawl_etl.py`) to use the execution date (associated with a given DAG run; see https://airflow.apache.org/docs/1.10.9/concepts.html?highlight=concepts#execution-date).  This allows re-running for a previous date, and also fixes some bugs arising from faulty assumptions about the scheduling of upstream CommonCrawl pipelines.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the *default* branch of the repository (`main` or `master`).
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
