### PR TITLE
Create MockImageStore class for testing

### DIFF
--- a/src/cc_catalog_airflow/dags/provider_api_scripts/common/storage/image.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/common/storage/image.py
@@ -400,3 +400,78 @@ class ImageStore:
         else:
             logger.debug(f'Enriching tag: {tag}')
             return {'name': tag, 'provider': self._PROVIDER}
+
+
+class MockImageStore(ImageStore):
+    """
+    A class that mocks the role of the ImageStore class. This class replaces
+    all functionality of ImageStore that calls the internet.
+
+    For information about all arguments other than license_info refer to
+    ImageStore class.
+
+    Required init arguments:
+    license_info:       A named tuple consisting of valid license info from
+                        the test script in which MockImageStore is being used.
+    """
+
+    def __init__(
+            self,
+            provider=None,
+            output_file=None,
+            output_dir=None,
+            buffer_length=100,
+            license_info=None
+    ):
+        logger.info(f'Initialized with provider {provider}')
+        super().__init__(provider=provider)
+        self.license_info = license_info
+
+    def _get_image(
+            self,
+            foreign_identifier,
+            foreign_landing_url,
+            image_url,
+            thumbnail_url,
+            width,
+            height,
+            license_url,
+            license_,
+            license_version,
+            creator,
+            creator_url,
+            title,
+            meta_data,
+            raw_tags,
+            watermarked,
+            source,
+    ):
+        valid_license_info = self.license_info
+
+        source = util.get_source(source, self._PROVIDER)
+        meta_data = self._enrich_meta_data(
+            meta_data,
+            license_url=valid_license_info.url,
+            raw_license_url=license_url
+        )
+        tags = self._enrich_tags(raw_tags)
+
+        return Image(
+            foreign_identifier=foreign_identifier,
+            foreign_landing_url=foreign_landing_url,
+            image_url=image_url,
+            thumbnail_url=thumbnail_url,
+            license_=valid_license_info.license,
+            license_version=valid_license_info.version,
+            width=width,
+            height=height,
+            filesize=None,
+            creator=creator,
+            creator_url=creator_url,
+            title=title,
+            meta_data=meta_data,
+            tags=tags,
+            watermarked=watermarked,
+            provider=self._PROVIDER,
+            source=source
+        )

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_cleveland_museum_of_art.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_cleveland_museum_of_art.py
@@ -3,10 +3,22 @@ import json
 import requests
 import os
 from unittest.mock import patch, MagicMock
-
-import pytest
+from common.storage.image import MockImageStore
+from collections import namedtuple
 
 import cleveland_museum_of_art as clm
+
+
+LicenseInfo = namedtuple(
+    'LicenseInfo',
+    ['license', 'version', 'url']
+)
+_license_info = ('cc0', '1.0', 'https://creativecommons.org/publicdomain/zero/1.0/')
+license_info = LicenseInfo(*_license_info)
+clm.image_store = MockImageStore(
+                    provider=clm.PROVIDER,
+                    license_info=license_info
+                    )
 
 RESOURCES = os.path.join(
     os.path.abspath(os.path.dirname(__file__)),
@@ -158,7 +170,6 @@ def test_get_response_failure():
     assert mock_get.call_count == 3
 
 
-@pytest.mark.skip(reason='This test calls the internet via ImageStore')
 def test_handle_response():
     response_json = _get_resource_json('handle_response_data.json')
     data = response_json['data']

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_raw_pixel.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_raw_pixel.py
@@ -2,10 +2,21 @@ import json
 import logging
 import os
 from unittest.mock import patch
-
-import pytest
+from collections import namedtuple
+from common.storage.image import MockImageStore
 
 import raw_pixel as rwp
+
+LicenseInfo = namedtuple(
+    'LicenseInfo',
+    ['license', 'version', 'url']
+)
+_license_info = ('cc0', '1.0', 'https://creativecommons.org/publicdomain/zero/1.0/')
+license_info = LicenseInfo(*_license_info)
+rwp.image_store = MockImageStore(
+                    provider=rwp.PROVIDER,
+                    license_info=license_info
+                    )
 
 RESOURCES = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), "tests/resources/rawpixel"
@@ -45,7 +56,6 @@ def test_process_pages_giving_zero():
         assert img_ctr == 0
 
 
-@pytest.mark.skip(reason='This test calls the internet via ImageStore')
 def test_process_image_data():
     r = _get_resource_json("total_images_example.json")
     with patch.object(rwp, "_request_content", return_value=r):

--- a/src/cc_catalog_airflow/dags/provider_api_scripts/test_science_museum.py
+++ b/src/cc_catalog_airflow/dags/provider_api_scripts/test_science_museum.py
@@ -3,10 +3,22 @@ import json
 import logging
 import requests
 from unittest.mock import MagicMock, patch
-
-import pytest
+from collections import namedtuple
+from common.storage.image import MockImageStore
 
 import science_museum as sm
+
+LicenseInfo = namedtuple(
+    'LicenseInfo',
+    ['license', 'version', 'url']
+)
+_license_info = ('by-nc-sa', '4.0', 'https://creativecommons.org/licenses/by-nc-sa/4.0/')
+license_info = LicenseInfo(*_license_info)
+sm.image_store = MockImageStore(
+                    provider=sm.PROVIDER,
+                    license_info=license_info
+                    )
+
 
 RESOURCES = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), 'tests/resources/sciencemuseum'
@@ -343,7 +355,6 @@ def test_get_metadata():
     assert actual_metadata == expected_metadata
 
 
-@pytest.mark.skip(reason='This test calls the internet via ImageStore')
 def test_handle_obj_data():
     object_data = _get_resource_json("objects_data.json")
     actual_image_count = sm._handle_object_data(object_data)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #463 by @mathemancer 

## Description
<!-- Concisely describe what the pull request does. -->
The PR creates a `MockImageStore` class within the `image.py` file. The class inherits most functionality from the origin, but overrides anything that calls the internet.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Relevant changes have been made in below mentioned files to make them work with the new class:
1. src/cc_catalog_airflow/dags/provider_api_scripts/test_cleveland_museum_of_art.py
2. src/cc_catalog_airflow/dags/provider_api_scripts/test_raw_pixel.py
3. src/cc_catalog_airflow/dags/provider_api_scripts/test_science_museum.py

These were the files that orginally called the internet via `ImageStore`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
